### PR TITLE
Install MariaDB 10.2

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -7,10 +7,16 @@
     - "{{ ansible_os_family }}.yml"
   tags: mariadb
 
+- name: Add MariaDB repo
+  template:
+    src: mariadb.repo.j2
+    dest: /etc/yum.repos.d/mariadb.repo
+
 - name: Install packages
   package:
     name: "{{ item }}"
     state: installed
+    enablerepo: mariadb
   with_items: "{{ mariadb_packages }}"
   tags: mariadb
 

--- a/templates/mariadb.repo.j2
+++ b/templates/mariadb.repo.j2
@@ -1,0 +1,7 @@
+# MariaDB CentOS {{ ansible_distribution_major_version|int }} repository list
+# http://mariadb.org/mariadb/repositories/
+[mariadb]
+name = MariaDB
+baseurl = http://yum.mariadb.org/{{ mariadb_version }}/centos{{ ansible_distribution_major_version|int }}-amd64
+gpgkey = https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
+gpgcheck = 1

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -2,11 +2,13 @@
 ---
 
 mariadb_packages:
-  - mariadb
-  - mariadb-server
+  - MariaDB
+  - MariaDB-server
   - MySQL-python
 
 mariadb_service: mariadb
 
 mariadb_config: /etc/my.cnf.d/network.cnf
 mariadb_my_config: ~/.my.cnf
+
+mariadb_version: 10.2


### PR DESCRIPTION
The version of the mariadb provided by the distribution is [too old](https://wikipedia.org/wiki/MariaDB). We need to install packages from the [official MariaDB repository](https://downloads.mariadb.org/mariadb/repositories/#mirror=timeweb&distro=CentOS&distro_release=centos7-amd64--centos7&version=10.2).