### PR TITLE
Put default char set and collation default as variable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,6 +9,10 @@ mariadb_version: '10.2'
 
 mariadb_swappiness: 0
 
+mariadb_character_set_server: utf8
+mariadb_collation_server: utf8_general_ci
+
+
 # Network configuration (network.cnf)
 mariadb_bind_address: '127.0.0.1'
 

--- a/templates/etc_my.cnf.d_server.cnf.j2
+++ b/templates/etc_my.cnf.d_server.cnf.j2
@@ -9,8 +9,8 @@ skip_name_resolve              = {{ mariadb_skip_name_resolve }}
 
 default_storage_engine         = InnoDB
 
-character_set_server           = utf8
-collation_server               = utf8_general_ci
+character_set_server           = {{mariadb_character_set_server}}
+collation_server               = {{mariadb_collation_server}}
 
 log_warnings                   = {{ mariadb_log_warnings }}
 slow_query_log                 = {{ mariadb_slow_query_log }}


### PR DESCRIPTION
Default character set and collation settings may require to change. Ref -

https://github.com/Icinga/icingaweb2-module-cube/issues/7