### PR TITLE
Update cache on package install

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -14,6 +14,7 @@
   package:
     name: "{{ item }}"
     state: installed
+    update_cache: yes
   with_items: "{{ mariadb_packages }}"
   tags: mariadb
 


### PR DESCRIPTION
Hi,

On first run, yum cache isn't up to date after yum_repository. So it fails with

```
TASK [bertvv.mariadb : Install packages] *****************************************************************************
failed: [dev.aws] (item=MariaDB) => {"changed": false, "item": "MariaDB", "msg": "No package matching 'MariaDB' found available, installed or updated", "rc": 126, "results": ["No package matching 'MariaDB' found available, installed orupdated"]}
```

Thanks for your work!