### PR TITLE
oraclelinux support (it's just a replace to centos for the yum repo)

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,7 +5,7 @@
   yum_repository:
     name: MariaDB
     description: Official MariaDB repository
-    baseurl: "http://yum.mariadb.org/{{ mariadb_version }}/{{ ansible_distribution|lower|regex_replace('redhat', 'rhel') }}{{ ansible_distribution_major_version }}-amd64"
+    baseurl: "http://yum.mariadb.org/{{ mariadb_version }}/{{ ansible_distribution|lower|regex_replace('redhat', 'rhel')|regex_replace('oraclelinux', 'centos') }}{{ ansible_distribution_major_version }}-amd64"
     gpgkey: https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
     gpgcheck: true
   tags: mariadb


### PR DESCRIPTION
Why to install mariadb on oraclelinux? well, it's a vagrant vm created for testing :)