### PR TITLE
Fix iteration for Python 3

### DIFF
--- a/templates/etc_my.cnf.d_custom.cnf.j2
+++ b/templates/etc_my.cnf.d_custom.cnf.j2
@@ -2,9 +2,9 @@
 #
 # {{ ansible_managed }}
 
-{% for section_name, section_contents in mariadb_custom_cnf.iteritems() %}
+{% for section_name, section_contents in mariadb_custom_cnf.items() %}
 [{{ section_name }}]
-{% for key, value in section_contents.iteritems() %}
+{% for key, value in section_contents.items() %}
 {% if value is defined and value %}
 {{ key }}={{ value }}
 {% else %}


### PR DESCRIPTION
In Python 3 there is only `dict.items()` and I needed to update this across different Ansible projects.