### PR TITLE
Fix for mysql module in newer ansibles

### DIFF
--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -6,6 +6,7 @@
     name: test
     login_user: root
     login_password: "{{ mariadb_root_password }}"
+    login_unix_socket: "{{ mariadb_socket }}"
     state: absent
   tags: mariadb
 
@@ -14,6 +15,7 @@
     name: "{{ item.name }}"
     login_user: root
     login_password: "{{ mariadb_root_password }}"
+    login_unix_socket: "{{ mariadb_socket }}"
     state: present
   with_items: "{{ mariadb_databases }}"
   register: db_creation
@@ -38,6 +40,7 @@
     target: "/tmp/{{ item.item.init_script|basename }}"
     login_user: root
     login_password: "{{ mariadb_root_password }}"
+    login_unix_socket: "{{ mariadb_socket }}"
   with_items: "{{ db_creation.results }}"
   when: item.changed and item.item.init_script is defined
   tags: mariadb

--- a/tasks/root-password.yml
+++ b/tasks/root-password.yml
@@ -15,6 +15,7 @@
     name: root
     password: "{{ mariadb_root_password }}"
     host: localhost
+    login_unix_socket: "{{ mariadb_socket }}"
     state: present
   when: root_pwd_check.rc == 0
   tags: mariadb
@@ -26,6 +27,7 @@
     host: "{{ item }}"
     login_user: root
     login_password: "{{ mariadb_root_password }}"
+    login_unix_socket: "{{ mariadb_socket }}"
     state: present
   with_items:
     - ::1

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -7,6 +7,7 @@
     host_all: true
     login_user: root
     login_password: "{{ mariadb_root_password }}"
+    login_unix_socket: "{{ mariadb_socket }}"
     state: absent
   tags: mariadb
 
@@ -19,6 +20,7 @@
     append_privs: "{{ item.append_privs|default('no') }}"
     login_user: root
     login_password: "{{ mariadb_root_password }}"
+    login_unix_socket: "{{ mariadb_socket }}"
     state: present
   with_items: "{{ mariadb_users }}"
   tags: mariadb


### PR DESCRIPTION
Hello,

If you use newer Ansible (i.e.: ansible 2.7.4), then you'll encounter an error when using `mysql` ansible module.

```
TASK [bertvv.mariadb : Remove the test database] *******************************************************************************************************************************************************************************************
fatal: []: FAILED! => {"changed": false, "msg": "unable to find /root/.my.cnf. Exception message: (2003, \"Can't connect to MySQL server on 'localhost' ([Errno 111] Connection refused)\")"}
```

This is because there's an update on using it. It requires server to have `.my.cnf` file with credentials, however I think it's better to bypass this with supplying `socket` location. With options added in this PR, this error goes away.