### PR TITLE
Update the "Check if root password is set" task logic

### DIFF
--- a/tasks/root-password.yml
+++ b/tasks/root-password.yml
@@ -9,12 +9,16 @@
       server!
   when: mariadb_root_password | length == 0
 
-# This command will fail when the root password was set previously
+# This command will succeed if the root password has been previously set
 - name: Check if root password is set
   shell: >
-    mysqladmin -u root status
+    mysql -u root
+    -p'{{ mariadb_root_password }}'
+    -h localhost
+    -S {{ mariadb_socket }}
+    -e "quit"
   changed_when: false
-  failed_when: false
+  ignore_errors: true
   register: root_pwd_check
   tags: mariadb
 
@@ -25,7 +29,7 @@
     host: localhost
     login_unix_socket: "{{ mariadb_socket }}"
     state: present
-  when: root_pwd_check.rc == 0
+  when: root_pwd_check.rc != 0
   tags: mariadb
 
 - name: Set MariaDB root password for 127.0.0.1, ::1
@@ -40,5 +44,5 @@
   with_items:
     - ::1
     - 127.0.0.1
-  when: root_pwd_check.rc == 0
+  when: root_pwd_check.rc != 0
   tags: mariadb


### PR DESCRIPTION
This is a fix for the following problem:

The `Set MariaDB root password for the first time (root@localhost)` task fails when a username and password is set for the `[mysqladmin]` section in the custom.cnf file.

See [issue 32](https://github.com/bertvv/ansible-role-mariadb/issues/32)