### PR TITLE
Authentication task changes for 10.4. These changes have two purposes:

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Issues, feature requests, ideas, suggestions, etc. are appreciated and can be po
 
 Pull requests are also very welcome. Please create a topic branch for your proposed changes. If you don’t, this will create conflicts in your fork when you synchronise changes after the merge. Don’t hesitate to add yourself to the contributor list below in your PR!
 
+- [@herd-the-cats](https://github.com/herd-the-cats)
 - [Adail Horst](https://github.com/SpawW)
 - [Barry Britt](https://github.com/raznikk)
 - [Bert Van Vreckem](https://github.com/bertvv/) (Maintainer)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,7 @@
 mariadb_databases: []
 mariadb_users: []
 mariadb_root_password: ''
+mariadb_auth_unix_plugin: false
 
 mariadb_mirror: yum.mariadb.org
 mariadb_version: '10.4'

--- a/tasks/auth-unix-plugin.yml
+++ b/tasks/auth-unix-plugin.yml
@@ -1,0 +1,35 @@
+# roles/mariadb/tasks/unix-socket-plugin.yml
+---
+# Shell is unfortunately necessary because the mysql_user module doesn't yet support plugin changes.
+- name: Enable plugin unix_socket
+  shell: >
+    mysql -S {{ mariadb_socket }} -u root -e 
+    "INSTALL PLUGIN unix_socket SONAME 'auth_socket'"
+    ||
+    mysql -S {{ mariadb_socket }} -u root -p{{ mariadb_root_password }} -e 
+    "INSTALL PLUGIN unix_socket SONAME 'auth_socket'"
+  register: plugin_install_result
+  changed_when: plugin_install_result.rc == 0
+  failed_when: plugin_install_result.rc != 0 and 'already installed' not in plugin_install_result.stderr
+  no_log: true
+
+- name: Check for unix_socket in plugin column
+  shell: >
+    mysql -N -s -S {{ mariadb_socket }} -u root -e
+    "SELECT plugin from mysql.user WHERE user = 'root'"
+    ||
+    mysql -N -s -S {{ mariadb_socket }} -u root -p{{ mariadb_root_password }} -e
+    "SELECT plugin from mysql.user WHERE user = 'root'"
+  register: plugin_root_result
+  changed_when: plugin_root_result.stdout is not search('unix_socket')
+  no_log: true
+
+- name: Update root user to use unix_socket
+  shell: >
+    mysql -S {{ mariadb_socket }} -u root -e 
+    "UPDATE mysql.user SET plugin = 'unix_socket' WHERE user = 'root'; FLUSH PRIVILEGES;"
+    ||
+    mysql -S {{ mariadb_socket }} -u root -p{{ mariadb_root_password }} -e
+    "UPDATE mysql.user SET plugin = 'unix_socket' WHERE user = 'root'; FLUSH PRIVILEGES;"
+  when: plugin_root_result.stdout is not search('unix_socket')
+  no_log: true

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,31 @@
   tags: mariadb
 
 - include_tasks: install.yml
+
 - include_tasks: config.yml
+
+- name: Authentication changes in version 10.4 message
+  debug:
+    msg: >
+      Authentication has changed in version 10.4. Both the root user and
+      the user that owns the data directory (mysql by default) now utilize
+      the unix_socket plugin for passwordless access, and are created with
+      an invalid password. Therefore setting a password isn't required for
+      those user accounts accessing via the unix socket. Please see
+      https://mariadb.org/authentication-in-mariadb-10-4/ .
+      Skipping authentication setup tasks!
+  when: mariadb_version is version('10.4', '>=')
+
 - include_tasks: root-password.yml
+  when:
+  - not mariadb_auth_unix_plugin
+  - mariadb_version is version('10.4', '<')
+
+- include_tasks: auth-unix-plugin.yml
+  when:
+  - mariadb_auth_unix_plugin
+  - mariadb_version is version('10.4', '<')
+
 - include_tasks: databases.yml
+
 - include_tasks: users.yml

--- a/tasks/root-password.yml
+++ b/tasks/root-password.yml
@@ -9,14 +9,31 @@
       server!
   when: mariadb_root_password | length == 0
 
-# This command will fail when the root password was set previously
-- name: Check if root password is set
+# This command will exit non-zero when the root password was set previously
+- name: Check if root password is unset
   shell: >
     mysqladmin -u root status
   changed_when: false
   failed_when: false
   register: root_pwd_check
   tags: mariadb
+
+# Repeat runs with the same password can continue idempotently, otherwise fail.
+- name: Check if the specified root password is already set
+  shell: >
+    mysqladmin -u root -p{{ mariadb_root_password }} status
+  changed_when: false
+  no_log: true
+  when: root_pwd_check.rc != 0
+  tags: mariadb
+
+- name: Check for previously set unix_socket in plugin column
+  command: >
+    mysql -N -s -S {{ mariadb_socket }} -u root -e
+    "SELECT plugin from mysql.user WHERE user = 'root'"
+  register: plugin_root_result
+  changed_when: plugin_root_result.stdout is search('unix_socket')
+  when: root_pwd_check.rc == 0
 
 - name: Set MariaDB root password for the first time (root@localhost)
   mysql_user:
@@ -28,7 +45,15 @@
   when: root_pwd_check.rc == 0
   tags: mariadb
 
-- name: Set MariaDB root password for 127.0.0.1, ::1
+- name: Remove unix_socket plugin if previously set
+  command: >
+    mysql -S {{ mariadb_socket }} -u root -e
+    "UPDATE mysql.user SET plugin = '' WHERE user = 'root'; FLUSH PRIVILEGES;"
+  when:
+  - root_pwd_check.rc == 0
+  - plugin_root_result.stdout is search('unix_socket') 
+
+- name: Set MariaDB root password for 127.0.0.1, ::1, FQDN
   mysql_user:
     name: root
     password: "{{ mariadb_root_password }}"
@@ -40,5 +65,6 @@
   with_items:
     - ::1
     - 127.0.0.1
+    - "{{ ansible_fqdn }}"
   when: root_pwd_check.rc == 0
   tags: mariadb


### PR DESCRIPTION
one is to add unix_socket authentication capability via a boolean for
versions older than 10.4. The second is to skip password tasks for 10.4
because it has secure passwordless login with unix_socket by default.