### PR TITLE
Allows specific uid/gid for mysql user by creating it first. The pack…

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -11,6 +11,13 @@ mariadb_version: '10.4'
 mariadb_configure_swappiness: true
 mariadb_swappiness: 0
 
+# 27 is default in /usr/share/doc/setup-*/uidgid
+mariadb_system_user:
+  name: 'mysql'
+  uid: 27
+  gid: 27
+  shell: '/sbin/nologin'
+
 # Network configuration (network.cnf)
 
 mariadb_service: mariadb

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -10,6 +10,24 @@
     gpgcheck: true
   tags: mariadb
 
+- name: Create daemon group with specified gid
+  group:
+    name: "{{ mariadb_system_user.name }}"
+    gid: "{{ mariadb_system_user.gid }}"
+    system: true
+    state: present
+
+- name: Create daemon user with specified uid
+  user:
+    name: "{{ mariadb_system_user.name }}"
+    uid: "{{ mariadb_system_user.uid }}"
+    system: true
+    group: "{{ mariadb_system_user.name }}"
+    shell: "{{ mariadb_system_user.shell }}"
+    comment: MariaDB user
+    create_home: false
+    skeleton: false
+
 - name: Install packages
   package:
     name: "{{ item }}"


### PR DESCRIPTION
…age from the official MariaDB repo dynamically allocates a uid and gid under 1000 instead of using the reserved uid 27 of RHEL/Fedora. This can help ensure consistent uid across installs.