### PR TITLE
Feature - galera support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,20 +27,21 @@ None of the variables below are required. When not defined by the user, the [def
 
 ### Basic configuration
 
-| Variable                       | Default         | Comments                                                                                                    |
-| :---                           | :---            | :---                                                                                                        |
-| `mariadb_bind_address`         | '127.0.0.1'     | Set this to the IP address of the network interface to listen on, or '0.0.0.0' to listen on all interfaces. |
-| `mariadb_configure_swappiness` | true            | When `true`, this role will set the "swappiness" value (see `mariadb_swappiness`.                           |
-| `mariadb_custom_cnf`           | {}              | Dictionary with custom configuration.                                                                       |
-| `mariadb_databases`            | []              | List of dicts specifying the databases to be added. See below for details.                                  |
-| `mariadb_mirror`               | yum.mariadb.org | Download mirror for the .rpm package (1)                                                                    |
-| `mariadb_port`                 | 3306            | The port number used to listen to client requests                                                           |
-| `mariadb_root_password`        | ''              | The MariaDB root password. (2)                                 |
-| `mariadb_server_cnf`           | {}              | Dictionary with server configuration.                                                                       |
-| `mariadb_service  `            | mariadb         | Name of the service (should e.g. be 'mysql' on CentOS for MariaDB 5.5)                                      |
-| `mariadb_swappiness`           | 0               | "Swappiness" value. System default is 60. A value of 0 means that swapping out processes is avoided.        |
-| `mariadb_users`                | []              | List of dicts specifying the users to be added. See below for details.                                      |
-| `mariadb_version`              | '10.3'          | The version of MariaDB to be installed. Default is the current stable release.                              |
+| Variable                       | Default         | Comments                                                                                                        |
+| :---                           | :---            | :---                                                                                                            |
+| `mariadb_bind_address`         | '127.0.0.1'     | Set this to the IP address of the network interface to listen on, or '0.0.0.0' to listen on all interfaces.     |
+| `mariadb_configure_swappiness` | true            | When `true`, this role will set the "swappiness" value (see `mariadb_swappiness`.                               |
+| `mariadb_custom_cnf`           | {}              | Dictionary with custom configuration.                                                                           |
+| `mariadb_databases`            | []              | List of dicts specifying the databases to be added. See below for details.                                      |
+| `mariadb_mirror`               | yum.mariadb.org | Download mirror for the .rpm package (1)                                                                        |
+| `mariadb_port`                 | 3306            | The port number used to listen to client requests                                                               |
+| `mariadb_root_password`        | ''              | The MariaDB root password. (2)                                                                                  |
+| `mariadb_server_cnf`           | {}              | Dictionary with server configuration.                                                                           |
+| `mariadb_service  `            | mariadb         | Name of the service (should e.g. be 'mysql' on CentOS for MariaDB 5.5)                                          |
+| `mariadb_swappiness`           | 0               | "Swappiness" value. System default is 60. A value of 0 means that swapping out processes is avoided.            |
+| `mariadb_users`                | []              | List of dicts specifying the users to be added. See below for details.                                          |
+| `mariadb_version`              | '10.3'          | The version of MariaDB to be installed. Default is the current stable release.                                  |
+| `is_bootstrap_node`            | 'false'         | This is a host specific config option and determines whether the current node is the first node of the cluster. |
 
 **Remarks**
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,3 +21,6 @@ mariadb_server_cnf: {}
 
 # Custom configuration
 mariadb_custom_cnf: {}
+
+# Galera configuration
+is_bootstrap_node: false

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -31,9 +31,32 @@
   when: mariadb_configure_swappiness|bool
   tags: mariadb
 
-- name: Ensure service is started
+- name: Check if MariaDB Service Exists
+  stat: 
+    path: /etc/systemd/system/mysql.service
+  register: service_status
+
+- name: Ensure service is restarted
   service:
     name: "{{ mariadb_service }}"
-    state: started
+    state: restarted
     enabled: true
+  when: "'galera' not in role_names"
   tags: mariadb
+
+- name: Ensure node joins cluster
+  service:
+    name: "{{ mariadb_service }}"
+    state: restarted
+  when:
+    - service_status.stat.exists ==  False
+    - "'galera' in role_names"
+    - not is_bootstrap_node|bool
+  tags: mariadb
+
+- name: Ensure cluster is active
+  shell: galera_new_cluster
+  when:
+    - service_status.stat.exists ==  False
+    - "'galera' in role_names"
+    - is_bootstrap_node|bool

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -1,6 +1,11 @@
 # roles/mariadb/tasks/databases.yml
 ---
 
+- name: Check if MariaDB Service Exists
+  stat: 
+    path: /etc/systemd/system/mysql.service
+  register: service_status
+
 - name: Remove the test database
   mysql_db:
     name: test
@@ -8,6 +13,8 @@
     login_password: "{{ mariadb_root_password }}"
     login_unix_socket: "{{ mariadb_socket }}"
     state: absent
+  when:
+    - service_status.stat.exists == False
   tags: mariadb
 
 - name: Create user defined databases
@@ -19,6 +26,8 @@
     state: present
   with_items: "{{ mariadb_databases }}"
   register: db_creation
+  when:
+    - service_status.stat.exists == False
   tags: mariadb
 
 # Below, the databases are initialised, but only when the database was created
@@ -30,7 +39,9 @@
     dest: "/tmp/{{ item.item.init_script|basename }}"
     mode: '0600'
   with_items: "{{ db_creation.results }}"
-  when: item.changed and item.item.init_script is defined
+  when:
+    - item.changed and item.item.init_script is defined
+    - service_status.stat.exists == False
   tags: mariadb
 
 - name: Initialise databases
@@ -42,7 +53,9 @@
     login_password: "{{ mariadb_root_password }}"
     login_unix_socket: "{{ mariadb_socket }}"
   with_items: "{{ db_creation.results }}"
-  when: item.changed and item.item.init_script is defined
+  when:
+    - item.changed and item.item.init_script is defined
+    - service_status.stat.exists == False
   tags: mariadb
 
 - name: Delete init scripts from the server
@@ -50,5 +63,7 @@
     name: "/tmp/{{ item.item.init_script|basename }}"
     state: absent
   with_items: "{{ db_creation.results }}"
-  when: item.changed and item.item.init_script is defined
+  when:
+    - item.changed and item.item.init_script is defined
+    - service_status.stat.exists == False
   tags: mariadb

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -9,6 +9,8 @@
     login_password: "{{ mariadb_root_password }}"
     login_unix_socket: "{{ mariadb_socket }}"
     state: absent
+  when:
+    - service_status.stat.exists == False
   tags: mariadb
 
 - name: Create the users
@@ -23,4 +25,12 @@
     login_unix_socket: "{{ mariadb_socket }}"
     state: present
   with_items: "{{ mariadb_users }}"
+  when:
+    - service_status.stat.exists == False
   tags: mariadb
+  
+- name: Ensure the service is stopped when part of galera cluster
+  service: 
+    name: mariadb
+    state: stopped
+  when: "'galera' in role_names"


### PR DESCRIPTION
This feature allows to configure mariadb for a Galera cluster. The changes include one host specific variable to determine the role of the node in the cluster and some minor changes to the already existing code to configure and start mariadb.

| Variable | Value | Description |
| :--- | ---: | :--- |
| is_bootstrap_node | true | The current node is used to bootstrap the cluster. |
| is_bootstrap_node | false | The current node join the cluster. |
