### PR TITLE
2origin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ env:
       VERSION: 7
     - DISTRIBUTION: fedora
       VERSION: 30
+    - DISTRIBUTION: ubuntu
+      VERSION: 18
 
 services:
   - docker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 This file contains al notable changes to the mariadb Ansible role.
 
+#3.0.1 - 2020-04-24
+
+Added Ubuntu 18 and Centos 8 support.
+
+
+
+
 This file adheres to the guidelines of <http://keepachangelog.com/>. Versioning follows [Semantic Versioning](http://semver.org/).
 
 ## 3.0.0 - 2019-08-18

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![Build Status](https://travis-ci.org/bertvv/ansible-role-mariadb.svg?branch=master)](https://travis-ci.org/bertvv/ansible-role-mariadb)
 
 
-An Ansible role for managing MariaDB in RedHat-based distributions. Specifically, the responsibilities of this role are to:
+An Ansible role for managing MariaDB in RedHat-based distributions (Centos 7, 8, Fedora) and Ubuntu 18. Specifically, the responsibilities of this role are to:
 
 - Install MariaDB packages from the official MariaDB repositories
 - Remove unsafe defaults:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,6 +8,13 @@ mariadb_root_password: ''
 mariadb_mirror: yum.mariadb.org
 mariadb_version: '10.4'
 
+mariadb_apt_mirror: 'http://mirror.vpsfree.cz'
+mariadb_apt_repositories: "deb [arch=amd64,arm64,ppc64el] {{ mariadb_apt_mirror }}/mariadb/repo/{{ mariadb_version }}/{{ ansible_distribution | lower }} {{ ansible_distribution_release }} main"
+mariadb_pgp_key: "https://mariadb.org/mariadb_release_signing_key.asc"
+
+mariadb_apt_keyserver: 'keyserver.ubuntu.com'
+mariadb_apt_keyid: '0xF1656F24C74CD1D8'
+
 mariadb_configure_swappiness: true
 mariadb_swappiness: 0
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,7 +3,7 @@
 
 mariadb_databases: []
 mariadb_users: []
-mariadb_root_password: ''
+mariadb_root_password: root
 
 mariadb_mirror: yum.mariadb.org
 mariadb_version: '10.4'

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,16 +1,20 @@
 ---
 galaxy_info:
-  author: Bert Van Vreckem
+  author: Bert Van Vreckem, Balazs Petik
   description: Manage MariaDB on a RedHat based Linux distribution.
   license: BSD
-  min_ansible_version: 2.8
+  min_ansible_version: 2.9
   platforms:
     - name: EL
       versions:
         - 7
+        - 8
     - name: Fedora
       versions:
         - 30
+    - name: Ubuntu
+        versions:
+          - 18
   galaxy_tags:
     - database
     - sql

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -13,8 +13,8 @@ galaxy_info:
       versions:
         - 30
     - name: Ubuntu
-        versions:
-          - 18
+      versions:
+        - 18
   galaxy_tags:
     - database
     - sql

--- a/tasks/configubuntu.yml
+++ b/tasks/configubuntu.yml
@@ -1,0 +1,39 @@
+# roles/mariadb/tasks/configubuntu.yml
+---
+- name: Install server config file
+  template:
+    src: etc_my.cnf.d_server.cnf.j2
+    dest: "{{ mariadb_config_server }}"
+  notify: restart mariadb
+  tags: mariadb
+
+- name: Install network config file
+  lineinfile:
+    path: /etc/mysql/my.cnf
+    regexp: "^bind_address.*$"
+    line: "bind_address= {{ mariadb_bind_address }}"
+  notify: restart mariadb
+  tags: mariadb
+
+- name: Install custom config file
+  template:
+    src: etc_my.cnf.d_custom.cnf.j2
+    dest: "{{ mariadb_config_custom }}"
+  when: mariadb_custom_cnf|length != 0
+  notify: restart mariadb
+  tags: mariadb
+
+- name: Configure swappiness
+  sysctl:
+    name: vm.swappiness
+    value: "{{ mariadb_swappiness }}"
+    state: present
+  when: mariadb_configure_swappiness|bool
+  tags: mariadb
+
+- name: Ensure service is started
+  service:
+    name: "{{ mariadb_service }}"
+    state: started
+    enabled: true
+  tags: mariadb

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -20,6 +20,7 @@
   with_items: "{{ mariadb_databases }}"
   register: db_creation
   tags: mariadb
+#  debugger: always
 
 # Below, the databases are initialised, but only when the database was created
 # in the previous step. This ensures idempotence.
@@ -32,6 +33,7 @@
   with_items: "{{ db_creation.results }}"
   when: item.changed and item.item.init_script is defined
   tags: mariadb
+#  debugger: always
 
 - name: Initialise databases
   mysql_db:
@@ -44,6 +46,7 @@
   with_items: "{{ db_creation.results }}"
   when: item.changed and item.item.init_script is defined
   tags: mariadb
+#  debugger: always
 
 - name: Delete init scripts from the server
   file:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,6 +1,6 @@
 # roles/mariadb/tasks/install.yml
 ---
-- name: Add official MariaDB repository Centos 7 or Fedora 30
+- name: Add official MariaDB repository Centos/RedHat 7 or Fedora 30
   yum_repository:
     name: MariaDB
     description: Official MariaDB repository
@@ -10,22 +10,22 @@
   tags: mariadb
   become: true
   when:
-    - ansible_facts['distribution'] == "CentOS" or ansible_facts['distribution'] == "Fedora"
+    - ansible_os_family == "RedHat"
     - ansible_facts['distribution_major_version'] == "7" or ansible_facts['distribution_major_version'] == "30"
 
-- name: Check MariaDB Centos8 repo installed
+- name: Check MariaDB Centos/RegHat 8 repo installed
   stat:
     path: /etc/yum.repos.d/mariadb.repo
   register: c8Mariadbpreo
 
-- name: Install Centos 8 MariaDB repo
+- name: Install Centos/RedHat 8 MariaDB repo
   block:
-  - name: Get MariaDB repo installer Centos 8
+  - name: Get MariaDB repo installer RedHat 8
     get_url:
       url: https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
       dest: /tmp/mariadb_repo_setup
       mode: '0770'
-  - name: Install MariaDB repo script Centos8
+  - name: Install MariaDB repo script RedHat8
     shell: /tmp/mariadb_repo_setup
   - name: Remove repo installer script
     file:
@@ -33,7 +33,7 @@
       state: absent
   when:
     - not c8Mariadbpreo.stat.exists
-    - ansible_facts['distribution'] == "CentOS"
+    - ansible_os_family == "RedHat"
     - ansible_facts['distribution_major_version'] == "8"
 
 - name: Install Install MariaDB
@@ -43,13 +43,13 @@
   with_items: "{{ mariadb_packages }}"
   tags: mariadb
 
-- name: Install MySQL-python Centos7
+- name: Install MySQL-python Centos/RedHat 7
   package:
     name: MySQL-python
     state: installed
   tags: mariadb
   when:
-    - ansible_facts['distribution'] == "CentOS" or ansible_facts['distribution'] == "Fedora"
+    - ansible_os_family == "RedHat"
     - ansible_facts['distribution_major_version'] == "7" or ansible_facts['distribution_major_version'] == "30"
 
 
@@ -59,7 +59,7 @@
     state: installed
   when:
     - ansible_python['version']['major'] == 3
-    - ansible_facts['distribution'] == "CentOS"
+    - ansible_os_family == "RedHat"
     - ansible_facts['distribution_major_version'] == "8"
 
 - name: Install MySQL-python
@@ -68,5 +68,5 @@
     state: installed
   when:
     - ansible_python['version']['major'] == 2
-    - ansible_facts['distribution'] == "CentOS"
+    - ansible_os_family == "RedHat"
     - ansible_facts['distribution_major_version'] == "8"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,7 +1,6 @@
 # roles/mariadb/tasks/install.yml
 ---
-
-- name: Add official MariaDB repository
+- name: Add official MariaDB repository Centos 7 or Fedora 30
   yum_repository:
     name: MariaDB
     description: Official MariaDB repository
@@ -9,10 +8,65 @@
     gpgkey: https://yum.mariadb.org/RPM-GPG-KEY-MariaDB
     gpgcheck: true
   tags: mariadb
+  become: true
+  when:
+    - ansible_facts['distribution'] == "CentOS" or ansible_facts['distribution'] == "Fedora"
+    - ansible_facts['distribution_major_version'] == "7" or ansible_facts['distribution_major_version'] == "30"
 
-- name: Install packages
+- name: Check MariaDB Centos8 repo installed
+  stat:
+    path: /etc/yum.repos.d/mariadb.repo
+  register: c8Mariadbpreo
+
+- name: Install Centos 8 MariaDB repo
+  block:
+  - name: Get MariaDB repo installer Centos 8
+    get_url:
+      url: https://downloads.mariadb.com/MariaDB/mariadb_repo_setup
+      dest: /tmp/mariadb_repo_setup
+      mode: '0770'
+  - name: Install MariaDB repo script Centos8
+    shell: /tmp/mariadb_repo_setup
+  - name: Remove repo installer script
+    file:
+      path: /tmp/mariadb_repo_setup
+      state: absent
+  when:
+    - not c8Mariadbpreo.stat.exists
+    - ansible_facts['distribution'] == "CentOS"
+    - ansible_facts['distribution_major_version'] == "8"
+
+- name: Install Install MariaDB
   package:
     name: "{{ item }}"
     state: installed
   with_items: "{{ mariadb_packages }}"
   tags: mariadb
+
+- name: Install MySQL-python Centos7
+  package:
+    name: MySQL-python
+    state: installed
+  tags: mariadb
+  when:
+    - ansible_facts['distribution'] == "CentOS" or ansible_facts['distribution'] == "Fedora"
+    - ansible_facts['distribution_major_version'] == "7" or ansible_facts['distribution_major_version'] == "30"
+
+
+- name: Install MySQL-python
+  package:
+    name: "python3-PyMySQL"
+    state: installed
+  when:
+    - ansible_python['version']['major'] == 3
+    - ansible_facts['distribution'] == "CentOS"
+    - ansible_facts['distribution_major_version'] == "8"
+
+- name: Install MySQL-python
+  package:
+    name: "python-PyMySQL"
+    state: installed
+  when:
+    - ansible_python['version']['major'] == 2
+    - ansible_facts['distribution'] == "CentOS"
+    - ansible_facts['distribution_major_version'] == "8"

--- a/tasks/installubuntu.yml
+++ b/tasks/installubuntu.yml
@@ -30,8 +30,8 @@
     update_cache: yes
   tags: mariadb
 
-- debug:
-    msg: '{{ ansible_python["version"]["major"] }}'
+#- debug:
+#    msg: 'Python version:{{ ansible_python["version"]["major"] }}'
 
 
 - name: Install MySQL-python

--- a/tasks/installubuntu.yml
+++ b/tasks/installubuntu.yml
@@ -1,0 +1,47 @@
+# roles/mariadb/tasks/install.yml
+---
+- name: Check Python3 present
+  stat:
+    path: /usr/bin/python3
+  register: python3ok
+
+- name: correct python version selected
+  alternatives:
+    name: python
+    link: /usr/bin/python
+    path: /usr/bin/python3
+  when: python3ok.stat.exists
+
+- name: Add an Apt signing key from URL
+  apt_key:
+    url: "{{ mariadb_pgp_key }}"
+    state: present
+
+- name: Add official MariaDB repository
+  apt_repository:
+    repo: "{{ mariadb_apt_repositories }}"
+    state: present
+  tags: mariadb
+
+- name: Install Install MariaDB
+  apt:
+    name: "{{ mariadb_packages }}"
+    state: latest
+    update_cache: yes
+  tags: mariadb
+
+- debug:
+    msg: '{{ ansible_python["version"]["major"] }}'
+
+
+- name: Install MySQL-python
+  apt:
+    name: "python3-pymysql"
+    state: latest
+  when: ansible_python["version"]["major"] == 3
+
+- name: Install MySQL-python
+  apt:
+    name: "python-pymysql"
+    state: latest
+  when: ansible_python["version"]["major"] == 2

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - include_tasks: install.yml
   when:
-    - ansible_facts['distribution'] == "CentOS"
+    - ansible_os_family == "RedHat"
 
 - include_tasks: installubuntu.yml
   when:
@@ -18,7 +18,7 @@
 
 - include_tasks: config.yml
   when:
-    - ansible_facts['distribution'] == "CentOS"
+    - ansible_os_family == "RedHat"
 
 - include_tasks: configubuntu.yml
   when:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,21 @@
   tags: mariadb
 
 - include_tasks: install.yml
+  when:
+    - ansible_facts['distribution'] == "CentOS"
+
+- include_tasks: installubuntu.yml
+  when:
+    - ansible_facts['distribution'] == "Ubuntu"
+
 - include_tasks: config.yml
+  when:
+    - ansible_facts['distribution'] == "CentOS"
+
+- include_tasks: configubuntu.yml
+  when:
+    - ansible_facts['distribution'] == "Ubuntu"
+
 - include_tasks: root-password.yml
 - include_tasks: databases.yml
 - include_tasks: users.yml

--- a/tasks/root-password.yml
+++ b/tasks/root-password.yml
@@ -1,15 +1,5 @@
 # roles/mariadb/tasks/root-password.yml
 ---
-- name: Root cnf
-  blockinfile:
-    dest: /root/.my.cnf
-    block: |
-     [mysql]
-      user=root
-      password={{ mariadb_root_password }}
-    state: present
-    create: yes
-    mode: '0600'
 
 - name: Check if a custom root password is specified
   debug:

--- a/tasks/root-password.yml
+++ b/tasks/root-password.yml
@@ -1,5 +1,15 @@
 # roles/mariadb/tasks/root-password.yml
 ---
+- name: Root cnf
+  blockinfile:
+    dest: /root/.my.cnf
+    block: |
+     [mysql]
+      user=root
+      password={{ mariadb_root_password }}
+    state: present
+    create: yes
+    mode: '0600'
 
 - name: Check if a custom root password is specified
   debug:
@@ -19,10 +29,12 @@
   tags: mariadb
 
 - name: Set MariaDB root password for the first time (root@localhost)
+#  become_user: mysql
   mysql_user:
     name: root
     password: "{{ mariadb_root_password }}"
     host: localhost
+#    check_implicit_admin: yes
     login_unix_socket: "{{ mariadb_socket }}"
     state: present
   when: root_pwd_check.rc == 0

--- a/tasks/root-password.yml
+++ b/tasks/root-password.yml
@@ -7,7 +7,8 @@
       Warning!! the MariaDB root password was left empty. Please set a custom
       password with role variable mariadb_root_password to secure your database
       server!
-  when: mariadb_root_password | length == 0
+#  when: mariadb_root_password | length == 0   ---It is not Vault compatible
+  when: mariadb_root_password == ''
 
 # This command will fail when the root password was set previously
 - name: Check if root password is set

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -1,6 +1,5 @@
 # roles/mariadb/tasks/users.yml
 ---
-
 - name: Remove anonymous users
   mysql_user:
     name: ''

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,10 +1,8 @@
 # roles/mariadb/vars/RedHat.yml
 ---
-
 mariadb_packages:
   - MariaDB-common
   - MariaDB-server
-  - MySQL-python
 
 mariadb_socket: /var/lib/mysql/mysql.sock
 

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,0 +1,12 @@
+# roles/mariadb/vars/Ubuntu.yml
+---
+mariadb_packages:
+  - mariadb-common
+  - mariadb-server
+
+mariadb_socket: /var/run/mysqld/mysqld.sock
+mariadb_config_server: /etc/mysql/my.cnf
+mariadb_config_network: /etc/mysql/my.cnf
+mariadb_config_custom: /etc/mysql/mariadb.conf.d/custom.cnf
+
+mariadb_service: mariadb.service


### PR DESCRIPTION
Centos 8 and Ubuntu 18 support added.
Tested in official vagrant images.
Centos 8 uses mariadb's repo.
Ubuntu uses a mirror.
Python 3 compatibility. (New Python modules...)