### PR TITLE
Feature galera support

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,20 +26,24 @@ None of the variables below are required. When not defined by the user, the [def
 
 ### Basic configuration
 
-| Variable                       | Default         | Comments                                                                                                    |
-| :---                           | :---            | :---                                                                                                        |
-| `mariadb_bind_address`         | '127.0.0.1'     | Set this to the IP address of the network interface to listen on, or '0.0.0.0' to listen on all interfaces. |
-| `mariadb_configure_swappiness` | true            | When `true`, this role will set the "swappiness" value (see `mariadb_swappiness`.                           |
-| `mariadb_custom_cnf`           | {}              | Dictionary with custom configuration.                                                                       |
-| `mariadb_databases`            | []              | List of dicts specifying the databases to be added. See below for details.                                  |
-| `mariadb_mirror`               | yum.mariadb.org | Download mirror for the .rpm package (1)                                                                    |
-| `mariadb_port`                 | 3306            | The port number used to listen to client requests                                                           |
-| `mariadb_root_password`        | ''              | The MariaDB root password. (2)                                                                              |
-| `mariadb_server_cnf`           | {}              | Dictionary with server configuration.                                                                       |
-| `mariadb_service`              | mariadb         | Name of the service (should e.g. be 'mysql' on CentOS for MariaDB 5.5)                                      |
-| `mariadb_swappiness`           | 0               | "Swappiness" value. System default is 60. A value of 0 means that swapping out processes is avoided.        |
-| `mariadb_users`                | []              | List of dicts specifying the users to be added. See below for details.                                      |
-| `mariadb_version`              | '10.3'          | The version of MariaDB to be installed. Default is the current stable release.                              |
+| Variable                       | Default          | Comments                                                                                                                   |
+| :---                           | :---             | :---                                                                                                                       |
+| `mariadb_bind_address`         | '127.0.0.1'      | Set this to the IP address of the network interface to listen on, or '0.0.0.0' to listen on all interfaces.                |
+| `mariadb_configure_swappiness` | true             | When `true`, this role will set the "swappiness" value (see `mariadb_swappiness`.                                          |
+| `mariadb_custom_cnf`           | {}               | Dictionary with custom configuration.                                                                                      |
+| `mariadb_databases`            | []               | List of dicts specifying the databases to be added. See below for details.                                                 |
+| `mariadb_mirror`               | yum.mariadb.org  | Download mirror for the .rpm package (1)                                                                                   |
+| `mariadb_port`                 | 3306             | The port number used to listen to client requests                                                                          |
+| `mariadb_root_password`        | ''               | The MariaDB root password. (2)                                                                                             |
+| `mariadb_server_cnf`           | {}               | Dictionary with server configuration.                                                                                      |
+| `mariadb_service`              | mariadb          | Name of the service (should e.g. be 'mysql' on CentOS for MariaDB 5.5)                                                     |
+| `mariadb_swappiness`           | 0                | "Swappiness" value. System default is 60. A value of 0 means that swapping out processes is avoided.                       |
+| `mariadb_users`                | []               | List of dicts specifying the users to be added. See below for details.                                                     |
+| `mariadb_version`              | '10.3'           | The version of MariaDB to be installed. Default is the current stable release.                                             |
+| `mariadb_galera_cluster_name`  | 'Galera cluster' | The name of the Galera cluster                                                                                             |
+| `mariadb_galera_nodes`         | []               | List of dicts specifying the IPv4 addresses of the cluster nodes. See below for details                                    |
+| `mariadb_galera_master`        | false            | If defined, Galera will be used. When `true`, this role will use that node to bootstrap the cluster. See below for details |
+| `mariadb_galera_node_address`  | ''               | Set this to the IPv4 address of the network interface of the corresponding host that is used in `mariadb_galera_nodes`     |
 
 #### Remarks
 
@@ -125,6 +129,46 @@ mariadb_users:
     host: '192.168.56.%'
 ```
 
+### Adding Galera cluster nodes
+
+The IPv4 addresses specified in this section are used to populate a comma-seperated list for the Galera cluster(i.e. `wsrep_cluster_address="gcomm://<nodes>"`).
+
+An example:
+
+```Yaml
+# ansible/group_vars/db/vars.yml
+#
+# variables specific to all hosts in db group
+mariadb_galera_nodes:
+  - 192.168.56.2
+  - 192.168.56.3
+  - 192.168.56.4
+```
+
+It's necesarry to specify the role and node address per host. Currently you have to assign the first node in the group as the master since it will be provisioned first.
+
+An example:
+
+```Yaml
+# ansible/host_vars/db01.yml
+#
+# variables specific to db01
+---
+
+mariadb_galera_master: true
+mariadb_galera_node_address: 192.168.56.2
+```
+
+```Yaml
+# ansible/host_vars/db02.yml
+#
+# variables specific to db02
+---
+
+mariadb_galera_master: false
+mariadb_galera_node_address: 192.168.56.3
+```
+
 ## Dependencies
 
 No dependencies.
@@ -205,6 +249,7 @@ Pull requests are also very welcome. Please create a topic branch for your propo
 - [Bert Van Vreckem](https://github.com/bertvv/) (Maintainer)
 - [Cédric Delgehier](https://github.com/cdelgehier)
 - [Dachi Natsvlishvili](https://github.com/dachinat)
+- [@fpkmatthi](https://github.com/fpkmatthi)
 - [@herd-the-cats](https://github.com/herd-the-cats)
 - [Louis Tournayre](https://github.com/louiznk)
 - [@piuma](https://github.com/piuma)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -38,4 +38,3 @@ mariadb_custom_cnf: {}
 # Galera configuration
 mariadb_galera_cluster_name: 'Galera cluster'
 mariadb_galera_nodes: []
-mariadb_galera_master: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -24,6 +24,7 @@ mariadb_logrotate:
   rotate: 3
 
 # Network configuration (network.cnf)
+# NOTE: mariadb_bind_address cannot be localhost when used in a Galera cluster
 
 mariadb_service: mariadb
 mariadb_bind_address: '127.0.0.1'
@@ -33,3 +34,8 @@ mariadb_server_cnf: {}
 
 # Custom configuration
 mariadb_custom_cnf: {}
+
+# Galera configuration
+mariadb_galera_cluster_name: 'Galera cluster'
+mariadb_galera_nodes: []
+mariadb_galera_master: false

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -5,3 +5,12 @@
   service:
     name: '{{ mariadb_service }}'
     state: restarted
+
+- name: build and install Galera policy
+  command: "{{ item }}"
+  with_items:
+    - "checkmodule -M -m -o galera.mod galera.te"
+    - "semodule_package -o galera.pp -m galera.mod"
+    - "semodule -i galera.pp"
+    - "rm -rf /galera.*"
+  when: (semodule_loaded|changed or semodule_te|changed)

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,11 +6,9 @@
     name: '{{ mariadb_service }}'
     state: restarted
 
-- name: build and install Galera policy
+- name: build galera policy
   command: "{{ item }}"
   with_items:
-    - "checkmodule -M -m -o galera.mod galera.te"
-    - "semodule_package -o galera.pp -m galera.mod"
-    - "semodule -i galera.pp"
-    - "rm -rf /galera.*"
-  when: (semodule_loaded|changed or semodule_te|changed)
+    - "checkmodule -M -m -o /galera.mod /galera.te"
+    - "semodule_package -o /galera.pp -m /galera.mod"
+    - "semodule -i /galera.pp"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -48,6 +48,11 @@
   when: mariadb_logrotate.configure|bool
   tags: mariadb
 
+- name: Ensure Galera config file is removed before starting service
+  file:
+    path: /etc/my.cnf.d/galera.cnf
+    state: absent
+
 - name: Ensure service is started
   service:
     name: "{{ mariadb_service }}"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -52,8 +52,8 @@
   file:
     path: /etc/my.cnf.d/galera.cnf
     state: absent
-  tags: mariadb
-  
+  when: mariadb_galera_master is defined
+
 - name: Ensure service is started
   service:
     name: "{{ mariadb_service }}"

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -52,7 +52,8 @@
   file:
     path: /etc/my.cnf.d/galera.cnf
     state: absent
-
+  tags: mariadb
+  
 - name: Ensure service is started
   service:
     name: "{{ mariadb_service }}"

--- a/tasks/galera.yml
+++ b/tasks/galera.yml
@@ -1,0 +1,94 @@
+# roles/mariadb/tasks/galera.yml
+---
+
+# NOTE: This is to run the handlers before configuring galera
+#       if we don't do this, mariadb will restart after
+#       bootstrapping the cluster.
+- meta: flush_handlers
+
+- name: Enable galera repo
+  yum_repository: 
+    name: Galera
+    description: Galera yum repo
+    baseurl: http://releases.galeracluster.com/galera-3/centos/7/x86_64/
+    gpgkey: http://releases.galeracluster.com/GPG-KEY-galeracluster.com
+    gpgcheck: yes
+
+- name: Install dependancies
+  yum:
+    name: "{{ packages }}"
+  vars:
+    packages:
+    - galera
+    - rsync
+    - policycoreutils-python
+
+- name: Stop MySQL service
+  service:
+    name: "{{ mariadb_service }}"
+    state: stopped
+  tags: mariadb
+
+- name: Kill any remaining MySQL processes
+  command: "pkill mysqld"
+  ignore_errors: true
+  tags: mariadb
+
+- name: Ensure template config file is present
+  template:
+    src: etc_my.cnf.d_galera.cnf.j2
+    dest: /etc/my.cnf.d/galera.cnf
+    mode: 0644
+  tags: mariadb
+
+- name: Allow MySQL to listen on TCP ports 4567,4568  and 4444 
+  seport:
+    ports: 4567,4568,4444
+    proto: tcp
+    setype: mysqld_port_t 
+    state: present
+  tags: mariadb
+
+- name: Allow MySQL to listen on UDP port 4567
+  seport:
+    ports: 4567
+    proto: udp
+    setype: mysqld_port_t 
+    state: present
+  tags: mariadb
+
+- name: Change mysqld_t domain to permissive
+  selinux_permissive:
+    name: mysqld_t
+    permissive: true
+  tags: mariadb
+
+- name: Copy SELinux policy file
+  template: 
+    src: galera.te.j2
+    dest: /galera.te
+    mode: 0644
+  tags: mariadb
+
+- name: Compile SELinux policy file and import
+  shell: cd / && checkmodule -M -m galera.te -o galera.mod && semodule_package -m galera.mod -o galera.pp && semodule -i galera.pp && rm -rf /galera.*
+  tags: mariadb
+
+- name: Change mysqld_t domain to permissive
+  selinux_permissive:
+    name: mysqld_t
+    permissive: false
+  ignore_errors: yes
+  tags: mariadb
+
+- name: Bootstrap cluster
+  command: galera_new_cluster
+  when: mariadb_galera_master|bool
+  tags: mariadb
+
+- name: Join node to cluster
+  service:
+    name: "{{ mariadb_service }}"
+    state: started
+  when: not mariadb_galera_master|bool
+  tags: mariadb

--- a/tasks/galera.yml
+++ b/tasks/galera.yml
@@ -29,11 +29,6 @@
     state: stopped
   tags: mariadb
 
-- name: Kill any remaining MySQL processes
-  command: "pkill mysqld"
-  ignore_errors: true
-  tags: mariadb
-
 - name: Ensure template config file is present
   template:
     src: etc_my.cnf.d_galera.cnf.j2
@@ -70,14 +65,22 @@
     mode: 0644
   tags: mariadb
 
-- name: Compile SELinux policy file and import
-  shell: >
-    cd / &&
-    checkmodule -M -m galera.te -o galera.mod &&
-    semodule_package -m galera.mod -o galera.pp &&
-    semodule -i galera.pp &&
-    rm -rf /galera.*
+- name: Check if Galera module is loaded
+  command: semodule --list-modules
+  register: semodule_loaded
+  changed_when: '"galera" not in semodule_loaded.stdout'
   tags: mariadb
+
+- name: Copy Galera type enforcement file
+  template:
+    src: galera.te.j2
+    dest: /galera.te
+    mode: 0644
+  register: semodule_te
+  notify: build and install Galera policy
+  tags: mariadb
+
+- meta: flush_handlers
 
 - name: Change mysqld_t domain to permissive
   selinux_permissive:

--- a/tasks/galera.yml
+++ b/tasks/galera.yml
@@ -4,7 +4,9 @@
 # NOTE: This is to run the handlers before configuring galera
 #       if we don't do this, mariadb will restart after
 #       bootstrapping the cluster.
-- meta: flush_handlers
+- name: Flush handlers
+  meta: flush_handlers
+  tags: mariadb
 
 - name: Enable galera repo
   yum_repository:
@@ -58,13 +60,6 @@
     permissive: true
   tags: mariadb
 
-- name: Copy SELinux policy file
-  template:
-    src: galera.te.j2
-    dest: /galera.te
-    mode: 0644
-  tags: mariadb
-
 - name: Check if Galera module is loaded
   command: semodule --list-modules
   register: semodule_loaded
@@ -77,12 +72,24 @@
     dest: /galera.te
     mode: 0644
   register: semodule_te
-  notify: build and install Galera policy
+  notify: build galera policy
   tags: mariadb
 
-- meta: flush_handlers
+- name: Flush handlers
+  meta: flush_handlers
+  tags: mariadb
 
-- name: Change mysqld_t domain to permissive
+- name: Delete intermediary policy files
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "/galera.te"
+    - "/galera.mod"
+    - "/galera.pp"
+  tags: mariadb
+
+- name: Change mysqld_t domain to enforcing
   selinux_permissive:
     name: mysqld_t
     permissive: false

--- a/tasks/galera.yml
+++ b/tasks/galera.yml
@@ -7,21 +7,21 @@
 - meta: flush_handlers
 
 - name: Enable galera repo
-  yum_repository: 
+  yum_repository:
     name: Galera
     description: Galera yum repo
     baseurl: http://releases.galeracluster.com/galera-3/centos/7/x86_64/
     gpgkey: http://releases.galeracluster.com/GPG-KEY-galeracluster.com
-    gpgcheck: yes
+    gpgcheck: true
 
 - name: Install dependancies
   yum:
     name: "{{ packages }}"
   vars:
     packages:
-    - galera
-    - rsync
-    - policycoreutils-python
+      - galera
+      - rsync
+      - policycoreutils-python
 
 - name: Stop MySQL service
   service:
@@ -41,11 +41,11 @@
     mode: 0644
   tags: mariadb
 
-- name: Allow MySQL to listen on TCP ports 4567,4568  and 4444 
+- name: Allow MySQL to listen on TCP ports 4567,4568  and 4444
   seport:
     ports: 4567,4568,4444
     proto: tcp
-    setype: mysqld_port_t 
+    setype: mysqld_port_t
     state: present
   tags: mariadb
 
@@ -53,7 +53,7 @@
   seport:
     ports: 4567
     proto: udp
-    setype: mysqld_port_t 
+    setype: mysqld_port_t
     state: present
   tags: mariadb
 
@@ -64,21 +64,26 @@
   tags: mariadb
 
 - name: Copy SELinux policy file
-  template: 
+  template:
     src: galera.te.j2
     dest: /galera.te
     mode: 0644
   tags: mariadb
 
 - name: Compile SELinux policy file and import
-  shell: cd / && checkmodule -M -m galera.te -o galera.mod && semodule_package -m galera.mod -o galera.pp && semodule -i galera.pp && rm -rf /galera.*
+  shell: >
+    cd / &&
+    checkmodule -M -m galera.te -o galera.mod &&
+    semodule_package -m galera.mod -o galera.pp &&
+    semodule -i galera.pp &&
+    rm -rf /galera.*
   tags: mariadb
 
 - name: Change mysqld_t domain to permissive
   selinux_permissive:
     name: mysqld_t
     permissive: false
-  ignore_errors: yes
+  ignore_errors: true
   tags: mariadb
 
 - name: Bootstrap cluster

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -51,3 +51,8 @@
 - name: Create users
   include_tasks: users.yml
   tags: mariadb
+
+- name: Configure Galera
+  include_tasks: galera.yml
+  when: mariadb_galera_master is defined
+  tags: mariadb

--- a/templates/etc_my.cnf.d_galera.cnf.j2
+++ b/templates/etc_my.cnf.d_galera.cnf.j2
@@ -1,0 +1,20 @@
+[mysqld]
+binlog_format=ROW
+default-storage-engine=innodb
+innodb_autoinc_lock_mode=2
+bind-address={{ mariadb_bind_address }}
+
+# Galera Provider Configuration
+wsrep_on=ON
+wsrep_provider=/usr/lib64/galera-4/libgalera_smm.so
+
+# Galera Cluster Configuration
+wsrep_cluster_name="{{ mariadb_galera_cluster_name }}"
+wsrep_cluster_address="gcomm://{% for node in mariadb_galera_nodes %}{{ node }}{{ '' if loop.last else ',' }}{% endfor %}"
+
+# Galera Synchronization Configuration
+wsrep_sst_method=rsync
+
+# Galera Node Configuration
+wsrep_node_address="{{ mariadb_galera_node_address }}"
+wsrep_node_name="{{ inventory_hostname }}"

--- a/templates/galera.te.j2
+++ b/templates/galera.te.j2
@@ -1,0 +1,10 @@
+module galera 1.0;
+
+require {
+        type rsync_exec_t;
+        type mysqld_t;
+        class file { execute execute_no_trans getattr open read };
+}
+
+#============= mysqld_t ==============
+allow mysqld_t rsync_exec_t:file { execute execute_no_trans getattr open read };


### PR DESCRIPTION
At your request I added `tags: mariadb` to all tasks and the `mariadb_` preposition to the new role variables. (notify me if I forgot any)
In regard to the availability to external users, I used a Vagrant test environment with [bertv.rh-base](https://github.com/bertvv/ansible-role-rh-base):

1. Execute on all nodes to test if they all joined the cluster:
```Bash
sudo su
mysql -u root -p -e "SHOW STATUS LIKE 'wsrep_cluster_size'"
```

2. Test the availability to an external machine:
* Ansible rh-base firewall configuration:
```Yaml
rhbase_firewall_allow_ports:
  - 53/udp
  - 3306/tcp
  - 4567/tcp
  - 4567/udp
  - 4568/tcp
  - 4444/tcp
```
* Ansible database configuration:
```Yaml
mariadb_bind_address: '0.0.0.0'
mariadb_databases:
  - name: wordpress
mariadb_users:
  - name: fpkmatthi
    password: "{{ vault_mariadb_fpkmatthi_password }}"
    priv: 'wordpress.*:ALL'
    host: '%'
mariadb_root_password: "{{ vault_mariadb_root_password }}"
mariadb_galera_cluster_name: 'galera_cluster'
mariadb_galera_nodes:
 - 192.168.40.21
  - 192.168.40.22
  - 192.168.40.23
```
* Execute on a host that's not part of the cluster:
```Bash
mysql -u fpkmatthi -p -h 192.168.40.21 wordpress
``` 