### PR TITLE
Adding molecule directory to init_script path

### DIFF
--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -22,9 +22,9 @@
     mariadb_databases:
       - name: emptydb
       - name: app1db
-        init_script: ../common/init.sql
+        init_script: ../molecule/common/init.sql
       - name: app2db
-        init_script: ../common/init.sql
+        init_script: ../molecule/common/init.sql
     mariadb_users:
       - name: app1usr
         password: 'Ej{Quiv3'


### PR DESCRIPTION
Adding ../molecule/common/init.sql instead of ../common/init.sql so that init_script can run correctly at playbook execution.