### PR TITLE
Add support for Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/bertvv/ansible-role-mariadb.svg?branch=master)](https://travis-ci.org/bertvv/ansible-role-mariadb)
 
-An Ansible role for managing MariaDB in RedHat-based distributions. Specifically, the responsibilities of this role are to:
+An Ansible role for managing MariaDB in RedHat or Debian based distributions. Specifically, the responsibilities of this role are to:
 
 - Install MariaDB packages from the official MariaDB repositories
 - Remove unsafe defaults:
@@ -43,17 +43,20 @@ None of the variables below are required. When not defined by the user, the [def
 
 #### Remarks
 
-(1) Installing MariaDB from the default yum repository can be very slow (some users reported more than 10 minutes). The variable `mariadb_mirror` allows you to specify a custom download mirror closer to your geographical location that may speed up the installation process. E.g.:
+(1) Installing MariaDB from the official repository can be very slow (some users reported more than 10 minutes). The variable `mariadb_mirror` allows you to specify a custom download mirror closer to your geographical location that may speed up the installation process. E.g.:
 
 ```yaml
+# for RHEL/Fedora
 mariadb_mirror: 'mariadb.mirror.nucleus.be/yum'
+# for Debian
+mariadb_mirror: 'mirror.mva-n.net/mariadb/repo'
 ```
 
 (2) **It is highly recommended to set the database root password!** Leaving the password empty is a serious security risk. The role will issue a warning if the variable was not set.
 
 ### Server configuration
 
-You can specify the configuration in `/etc/my.cnf.d/server.cnf`, specifically in the `[mariadb]` section, by providing a dictionary of keys/values in the variable `mariadb_server_cnf`. Please refer to the [MariaDB Server System Variables documentation](https://mariadb.com/kb/en/mariadb/server-system-variables/) for details on the possible settings.
+You can specify the configuration in `/etc/my.cnf.d/server.cnf` (in RHEL/Fedora, `/etc/mysql/conf.d/server.cnf` in Debian), specifically in the `[mariadb]` section, by providing a dictionary of keys/values in the variable `mariadb_server_cnf`. Please refer to the [MariaDB Server System Variables documentation](https://mariadb.com/kb/en/mariadb/server-system-variables/) for details on the possible settings.
 
 For settings that don't get a `= value` in the config file, leave the value empty. All values should be given as strings, so numerical values should be quoted.
 
@@ -76,7 +79,7 @@ slow-query-log-file = mariadb-slow.log
 
 ### Custom configuration
 
-Settings for other sections than `[mariadb]`, can be set with `mariadb_custom_cnf`. These settings will be written to `/etc/mysql/my.cnf.d/custom.cnf`.
+Settings for other sections than `[mariadb]`, can be set with `mariadb_custom_cnf`. These settings will be written to `/etc/mysql/my.cnf.d/custom.cnf` (in RHEL/Fedora, `/etc/mysql/conf.d/custom.cnf` in Debian).
 
 Just like `mariadb_server_cnf`, the variable `mariadb_custom_cnf` should be a dictionary. Keys are section names and values are dictionaries with key-value mappings for individual settings.
 
@@ -217,3 +220,4 @@ Pull requests are also very welcome. Please create a topic branch for your propo
 - [Thomas Eylenbosch](https://github.com/EylenboschThomas)
 - [Tom Stechele](https://github.com/tomstechele)
 - [Vincenzo Castiglia](https://github.com/CastixGitHub)
+- [@nxet](https://github.com/nxet)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ None of the variables below are required. When not defined by the user, the [def
 | `mariadb_service`              | mariadb         | Name of the service (should e.g. be 'mysql' on CentOS for MariaDB 5.5)                                       |
 | `mariadb_swappiness`           | '0'             | "Swappiness" value (string). System default is 60. A value of 0 means that swapping out processes is avoided.|
 | `mariadb_users`                | []              | List of dicts specifying the users to be added. See below for details.                                       |
-| `mariadb_version`              | '10.4'          | The version of MariaDB to be installed. Default is the current stable release.                               |
+| `mariadb_version`              | '10.5'          | The version of MariaDB to be installed. Default is the current stable release.                               |
 
 #### Remarks
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ An Ansible role for managing MariaDB in RedHat or Debian based distributions. Sp
     - remove test database
 - Create users and databases
 - Manage configuration files `server.cnf` and `custom.cnf`
+- Upload SSL certificates and configure the server to use them
 
 Refer to the [change log](CHANGELOG.md) for notable changes in each release.
 
@@ -40,6 +41,9 @@ None of the variables below are required. When not defined by the user, the [def
 | `mariadb_swappiness`           | '0'             | "Swappiness" value (string). System default is 60. A value of 0 means that swapping out processes is avoided.|
 | `mariadb_users`                | []              | List of dicts specifying the users to be added. See below for details.                                       |
 | `mariadb_version`              | '10.5'          | The version of MariaDB to be installed. Default is the current stable release.                               |
+| `mariadb_ssl_ca_crt`           | null            | Path to the certificate authority's root certificate                  |
+| `mariadb_ssl_server_crt`       | null            | Path to the server's SSL certificate                                  |
+| `mariadb_ssl_server_key`       | null            | Path to the server's SSL certificate key                                 |
 
 #### Remarks
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -35,3 +35,8 @@ mariadb_server_cnf: {}
 
 # Custom configuration
 mariadb_custom_cnf: {}
+
+# SSL certificates
+mariadb_ssl_ca_crt: null
+mariadb_ssl_server_crt: null
+mariadb_ssl_server_key: null

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,7 +7,7 @@ mariadb_root_password: ''
 mariadb_auth_unix_plugin: false
 
 mariadb_mirror: yum.mariadb.org
-mariadb_version: '10.4'
+mariadb_version: '10.5'
 
 mariadb_configure_swappiness: true
 mariadb_swappiness: "0"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -12,6 +12,9 @@ galaxy_info:
     - name: Fedora
       versions:
         - 31
+    - name: Debian
+      versions:
+        - 10
   galaxy_tags:
     - database
     - sql

--- a/tasks/add-repo.yml
+++ b/tasks/add-repo.yml
@@ -5,6 +5,7 @@
   template:
     src: etc_yum.repos.d_mariadb.repo.j2
     dest: /etc/yum.repos.d/MariaDB.repo
+    mode: '0644'
   when: ansible_distribution != 'Debian'
   tags: mariadb
 
@@ -27,6 +28,7 @@
   template:
     src: etc_apt_sources.list.d_mariadb.list.j2
     dest: /etc/apt/sources.list.d/mariadb.list
+    mode: '0644'
   when: ansible_distribution == 'Debian'
   tags: mariadb
 

--- a/tasks/add-repo.yml
+++ b/tasks/add-repo.yml
@@ -29,3 +29,9 @@
     dest: /etc/apt/sources.list.d/mariadb.list
   when: ansible_distribution == 'Debian'
   tags: mariadb
+
+- name: Update packages cache with new repo (apt)
+  apt:
+    update_cache: true
+  when: ansible_distribution == 'Debian'
+  tags: mariadb

--- a/tasks/add-repo.yml
+++ b/tasks/add-repo.yml
@@ -1,0 +1,31 @@
+# roles/mariadb/tasks/install/add-repo.yml
+---
+
+- name: Add official MariaDB repository (yum)
+  template:
+    src: etc_yum.repos.d_mariadb.repo.j2
+    dest: /etc/yum.repos.d/MariaDB.repo
+  when: ansible_distribution != 'Debian'
+  tags: mariadb
+
+
+- name: Install gpg to add repokey (apt)
+  package:
+    name: gpg
+    state: latest
+  when: ansible_distribution == 'Debian'
+  tags: mariadb
+
+- name: Add official MariaDB repository key (apt)
+  apt_key:
+    url: https://mariadb.org/mariadb_release_signing_key.asc
+    state: present
+  when: ansible_distribution == 'Debian'
+  tags: mariadb
+
+- name: Add official MariaDB repository (apt)
+  template:
+    src: etc_apt_sources.list.d_mariadb.list.j2
+    dest: /etc/apt/sources.list.d/mariadb.list
+  when: ansible_distribution == 'Debian'
+  tags: mariadb

--- a/tasks/certificates.yml
+++ b/tasks/certificates.yml
@@ -36,9 +36,9 @@
     group: "{{ mariadb_system_user.gid }}"
   tags: mariadb
 
-- name: Add SSL configuration to server.cnf
+- name: Add SSL configuration
   blockinfile:
-    path: "{{ mariadb_config_server }}"
+    path: "{{ mariadb_config_directory }}/90-ssl.cnf"
     content: |
       [server]
       ssl_ca = {{ mariadb_config_certificates }}/ca.crt

--- a/tasks/certificates.yml
+++ b/tasks/certificates.yml
@@ -1,0 +1,53 @@
+---
+
+- name: Create destination directory
+  file:
+    path: "{{ mariadb_config_certificates }}"
+    state: directory
+    mode: '750'
+    owner: "{{ mariadb_system_user.uid }}"
+    group: "{{ mariadb_system_user.gid }}"
+  tags: mariadb
+
+- name: Copy root certificate
+  copy:
+    content: "{{ lookup('file', mariadb_ssl_ca_crt) }}"
+    dest: "{{ mariadb_config_certificates }}/ca.crt"
+    mode: '0644'
+    owner: "{{ mariadb_system_user.uid }}"
+    group: "{{ mariadb_system_user.gid }}"
+  tags: mariadb
+
+- name: Copy server's SSL certificate
+  copy:
+    content: "{{ lookup('file', mariadb_ssl_server_crt) }}"
+    dest: "{{ mariadb_config_certificates }}/server.crt"
+    mode: '0644'
+    owner: "{{ mariadb_system_user.uid }}"
+    group: "{{ mariadb_system_user.gid }}"
+  tags: mariadb
+
+- name: Copy server's SSL certificate key
+  copy:
+    content: "{{ lookup('file', mariadb_ssl_server_key) }}"
+    dest: "{{ mariadb_config_certificates }}/server.key"
+    mode: '0600'
+    owner: "{{ mariadb_system_user.uid }}"
+    group: "{{ mariadb_system_user.gid }}"
+  tags: mariadb
+
+- name: Add SSL configuration to server.cnf
+  blockinfile:
+    path: "{{ mariadb_config_server }}"
+    content: |
+      [server]
+      ssl_ca = {{ mariadb_config_certificates }}/ca.crt
+      ssl_cert = {{ mariadb_config_certificates }}/server.crt
+      ssl_key = {{ mariadb_config_certificates }}/server.key
+    marker: "# server-wide SSL configuration {mark} Ansible managed"
+    create: yes
+    mode: '640'
+    owner: "{{ mariadb_system_user.uid }}"
+    group: "{{ mariadb_system_user.gid }}"
+  notify: restart mariadb
+  tags: mariadb

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -5,6 +5,9 @@
   template:
     src: etc_my.cnf.d_server.cnf.j2
     dest: "{{ mariadb_config_server }}"
+    mode: '0640'
+    owner: "{{ mariadb_system_user.uid }}"
+    group: "{{ mariadb_system_user.gid }}"
   notify: restart mariadb
   tags: mariadb
 
@@ -12,6 +15,9 @@
   template:
     src: etc_my.cnf.d_network.cnf.j2
     dest: "{{ mariadb_config_network }}"
+    mode: '0640'
+    owner: "{{ mariadb_system_user.uid }}"
+    group: "{{ mariadb_system_user.gid }}"
   notify: restart mariadb
   tags: mariadb
 
@@ -19,6 +25,9 @@
   template:
     src: etc_my.cnf.d_custom.cnf.j2
     dest: "{{ mariadb_config_custom }}"
+    mode: '0640'
+    owner: "{{ mariadb_system_user.uid }}"
+    group: "{{ mariadb_system_user.gid }}"
   when: mariadb_custom_cnf|length != 0
   notify: restart mariadb
   tags: mariadb
@@ -45,13 +54,14 @@
     path: /var/log/mariadb
     owner: mysql
     group: mysql
-    mode: 0755
+    mode: '0755'
   when: mariadb_logrotate.configure|bool
 
 - name: Configure logrotate
   template:
     src: etc_logrotate.d_mysql.j2
     dest: /etc/logrotate.d/mysql
+    mode: '0644'
   when: mariadb_logrotate.configure|bool
   notify: restart mariadb
   tags: mariadb

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -11,8 +11,7 @@
     gid: "{{ mariadb_system_user.gid }}"
     system: true
     state: present
-  when:
-    - ansible_distribution != 'Debian'
+    non_unique: true # necessary on Debian
   tags: mariadb
 
 - name: Create daemon user with specified uid
@@ -25,8 +24,6 @@
     home: "{{ mariadb_system_user.home }}"
     create_home: false
     shell: "{{ mariadb_system_user.shell }}"
-  when:
-    - ansible_distribution != 'Debian'
   tags: mariadb
 
 - name: Install packages

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,9 +2,7 @@
 ---
 
 - name: Add official MariaDB repository
-  template:
-    src: etc_yum.repos.d_mariadb.repo.j2
-    dest: /etc/yum.repos.d/MariaDB.repo
+  include_tasks: add-repo.yml
   tags: mariadb
 
 - name: Create daemon group with specified gid
@@ -13,6 +11,8 @@
     gid: "{{ mariadb_system_user.gid }}"
     system: true
     state: present
+  when:
+    - ansible_distribution != 'Debian'
   tags: mariadb
 
 - name: Create daemon user with specified uid
@@ -25,10 +25,12 @@
     home: "{{ mariadb_system_user.home }}"
     create_home: false
     shell: "{{ mariadb_system_user.shell }}"
+  when:
+    - ansible_distribution != 'Debian'
   tags: mariadb
 
 - name: Install packages
   package:
     name: "{{ mariadb_packages }}"
-    state: installed
+    state: "{{ 'latest' if ansible_distribution == 'Debian' else 'installed' }}"
   tags: mariadb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,14 @@
   include_tasks: config.yml
   tags: mariadb
 
+- name: Add SSL certificates
+  include_tasks: certificates.yml
+  when:
+    - mariadb_ssl_ca_crt != None
+    - mariadb_ssl_server_crt != None
+    - mariadb_ssl_server_key != None
+  tags: mariadb
+
 - name: Authentication changes in version 10.4 message
   debug:
     msg: >

--- a/templates/etc_apt_sources.list.d_mariadb.list.j2
+++ b/templates/etc_apt_sources.list.d_mariadb.list.j2
@@ -1,4 +1,4 @@
 # MariaDB repository list - Ansible managed
 # http://downloads.mariadb.org/mariadb/repositories/
-deb [arch=amd64] https://{{ mariadb_mirror }}/{{ mariadb_version }}/debian {{ ansible_distribution_release }} main
-deb-src https://{{ mariadb_mirror }}/{{ mariadb_version }}/debian {{ ansible_distribution_release }} main
+deb [arch=amd64] http://{{ mariadb_mirror }}/{{ mariadb_version }}/debian {{ ansible_distribution_release }} main
+deb-src http://{{ mariadb_mirror }}/{{ mariadb_version }}/debian {{ ansible_distribution_release }} main

--- a/templates/etc_apt_sources.list.d_mariadb.list.j2
+++ b/templates/etc_apt_sources.list.d_mariadb.list.j2
@@ -1,0 +1,4 @@
+# MariaDB repository list - Ansible managed
+# http://downloads.mariadb.org/mariadb/repositories/
+deb [arch=amd64] https://{{ mariadb_mirror }}/{{ mariadb_version }}/debian {{ ansible_distribution_release }} main
+deb-src https://{{ mariadb_mirror }}/{{ mariadb_version }}/debian {{ ansible_distribution_release }} main

--- a/templates/etc_logrotate.d_mysql.j2
+++ b/templates/etc_logrotate.d_mysql.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-# This logname can be set in /etc/my.cnf
+# This logname can be set in /etc/{{ 'mysql/' if ansible_distribution == 'Debian' else '' }}my.cnf
 # by setting the variable "log-error"
 # in the [mysqld] section as follows:
 #

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -21,4 +21,5 @@ mariadb_socket: /run/mysqld/mysqld.sock
 mariadb_config_network: /etc/mysql/conf.d/network.cnf
 mariadb_config_server: /etc/mysql/conf.d/server.cnf
 mariadb_config_custom: /etc/mysql/conf.d/custom.cnf
+mariadb_config_certificates: /etc/mysql/conf.d/certificates
 mariadb_config_logrotate: /etc/logrotate.d/mysql

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,0 +1,16 @@
+# roles/mariadb/vars/Debian.yml
+---
+
+mariadb_packages:
+  - mariadb-common
+  - mariadb-server
+  - python3-pymysql
+
+mariadb_mirror: mirror.mva-n.net/mariadb/repo
+
+mariadb_socket: /run/mysqld/mysqld.sock
+
+mariadb_config_network: /etc/mysql/conf.d/network.cnf
+mariadb_config_server: /etc/mysql/conf.d/server.cnf
+mariadb_config_custom: /etc/mysql/conf.d/custom.cnf
+mariadb_config_logrotate: /etc/logrotate.d/mysql

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,14 +8,6 @@ mariadb_packages:
 
 mariadb_mirror: mirror.mva-n.net/mariadb/repo
 
-mariadb_system_user:
-  name: 'mysql'
-  uid: 106
-  gid: 112
-  shell: '/sbin/nologin'
-  home: '/var/lib/mysql'
-  comment: 'MySQL Server'
-
 mariadb_socket: /run/mysqld/mysqld.sock
 
 mariadb_config_network: /etc/mysql/conf.d/network.cnf

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -8,6 +8,14 @@ mariadb_packages:
 
 mariadb_mirror: mirror.mva-n.net/mariadb/repo
 
+mariadb_system_user:
+  name: 'mysql'
+  uid: 106
+  gid: 112
+  shell: '/sbin/nologin'
+  home: '/var/lib/mysql'
+  comment: 'MySQL Server'
+
 mariadb_socket: /run/mysqld/mysqld.sock
 
 mariadb_config_network: /etc/mysql/conf.d/network.cnf

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -10,8 +10,9 @@ mariadb_mirror: mirror.mva-n.net/mariadb/repo
 
 mariadb_socket: /run/mysqld/mysqld.sock
 
-mariadb_config_network: /etc/mysql/conf.d/network.cnf
-mariadb_config_server: /etc/mysql/conf.d/server.cnf
-mariadb_config_custom: /etc/mysql/conf.d/custom.cnf
-mariadb_config_certificates: /etc/mysql/conf.d/certificates
+mariadb_config_directory: /etc/mysql/mariadb.conf.d
+mariadb_config_network: /etc/mysql/mariadb.conf.d/90-network.cnf
+mariadb_config_server: /etc/mysql/mariadb.conf.d/90-server.cnf
+mariadb_config_custom: /etc/mysql/mariadb.conf.d/99-custom.cnf
+mariadb_config_certificates: /etc/mysql/certificates
 mariadb_config_logrotate: /etc/logrotate.d/mysql

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -1,4 +1,4 @@
-# roles/mariadb/vars/RedHat.yml
+# roles/mariadb/vars/Fedora.yml
 ---
 
 mariadb_packages:
@@ -8,6 +8,7 @@ mariadb_packages:
 
 mariadb_socket: /var/lib/mysql/mysql.sock
 
+mariadb_config_directory: /etc/my.cnf.d
 mariadb_config_network: /etc/my.cnf.d/network.cnf
 mariadb_config_server: /etc/my.cnf.d/server.cnf
 mariadb_config_custom: /etc/my.cnf.d/custom.cnf

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -11,4 +11,5 @@ mariadb_socket: /var/lib/mysql/mysql.sock
 mariadb_config_network: /etc/my.cnf.d/network.cnf
 mariadb_config_server: /etc/my.cnf.d/server.cnf
 mariadb_config_custom: /etc/my.cnf.d/custom.cnf
+mariadb_config_certificates: /etc/my.cnf.d/certificates
 mariadb_config_logrotate: /etc/logrotate.d/mysql

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -11,3 +11,4 @@ mariadb_socket: /var/lib/mysql/mysql.sock
 mariadb_config_network: /etc/my.cnf.d/network.cnf
 mariadb_config_server: /etc/my.cnf.d/server.cnf
 mariadb_config_custom: /etc/my.cnf.d/custom.cnf
+mariadb_config_certificates: /etc/my.cnf.d/certificates

--- a/vars/RedHat-8.yml
+++ b/vars/RedHat-8.yml
@@ -1,4 +1,4 @@
-# roles/mariadb/vars/RedHat.yml
+# roles/mariadb/vars/RedHat-8.yml
 ---
 
 mariadb_packages:
@@ -8,6 +8,7 @@ mariadb_packages:
 
 mariadb_socket: /var/lib/mysql/mysql.sock
 
+mariadb_config_directory: /etc/my.cnf.d
 mariadb_config_network: /etc/my.cnf.d/network.cnf
 mariadb_config_server: /etc/my.cnf.d/server.cnf
 mariadb_config_custom: /etc/my.cnf.d/custom.cnf

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -8,6 +8,7 @@ mariadb_packages:
 
 mariadb_socket: /var/lib/mysql/mysql.sock
 
+mariadb_config_directory: /etc/my.cnf.d
 mariadb_config_network: /etc/my.cnf.d/network.cnf
 mariadb_config_server: /etc/my.cnf.d/server.cnf
 mariadb_config_custom: /etc/my.cnf.d/custom.cnf

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -11,4 +11,5 @@ mariadb_socket: /var/lib/mysql/mysql.sock
 mariadb_config_network: /etc/my.cnf.d/network.cnf
 mariadb_config_server: /etc/my.cnf.d/server.cnf
 mariadb_config_custom: /etc/my.cnf.d/custom.cnf
+mariadb_config_certificates: /etc/my.cnf.d/certificates
 mariadb_config_logrotate: /etc/logrotate.d/mysql


### PR DESCRIPTION
Added support for Debian 10 hosts, and other improvements.

##### Changes:
- `mariadb` version bumped from 10.4 to 10.5
- added `add-repo.yml` task file to handle repos based on different distro
- added `apt/sources.list.d` file template
- disabled user/group creation on Debian (taken care of by `apt`)
- added `vars/Debian.yml`
- updated meta and README
- improved permissions and ownership of config files
- SSL certs upload and config