### PR TITLE
Fix: missing line in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ This would result in the following `server.cnf`:
 [mariadb]
 slow-query-log
 slow-query-log-file = mariadb-slow.log
+long-query-time = 5.0
 ```
 
 ### Custom configuration


### PR DESCRIPTION
Added missing line `long-query-time` in example for server configuration

Not that I tested this, but it seems plausible