### PR TITLE
support rocky linux

### DIFF
--- a/templates/etc_yum.repos.d_mariadb.repo.j2
+++ b/templates/etc_yum.repos.d_mariadb.repo.j2
@@ -1,5 +1,5 @@
 [MariaDB]
-baseurl = "https://{{ mariadb_mirror }}/{{ mariadb_version }}/{{ ansible_distribution|lower|regex_replace('redhat', 'rhel')|regex_replace('oraclelinux', 'centos')|regex_replace('almalinux', 'centos') }}{{ ansible_distribution_major_version }}-amd64"
+baseurl = "https://{{ mariadb_mirror }}/{{ mariadb_version }}/{{ ansible_distribution|lower|regex_replace('redhat', 'rhel')|regex_replace('oraclelinux|rocky', 'centos')|regex_replace('almalinux', 'centos') }}{{ ansible_distribution_major_version }}-amd64"
 enabled = 1
 gpgcheck = 1
 gpgkey = https://yum.mariadb.org/RPM-GPG-KEY-MariaDB


### PR DESCRIPTION
this might not be future-proof because it assumes major version number synchronicity between centos and rocky. there won't be a centos 9 and then this solution will break. but this is how i made it work on a fresh rocky linux vm for now.