### PR TITLE
WIP: [FIX] support for MariaDB mirror URL config option `mariadb_mirror`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file adheres to the guidelines of <http://keepachangelog.com/>. Versioning 
 
 ### Changed
 
+- Use FQCNs for all tasks
 - Fix support for MariaDB mirror URL config option `mariadb_mirror`
 
 ## 3.1.3 - 2022-10-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Change log
 
-This file contains al notable changes to the mariadb Ansible role.
+This file contains all notable changes to the mariadb Ansible role.
 
 This file adheres to the guidelines of <http://keepachangelog.com/>. Versioning follows [Semantic Versioning](http://semver.org/).
+
+## 3.1.4
+
+### Changed
+
+- Fix support for MariaDB mirror URL config option `mariadb_mirror`
 
 ## 3.1.3 - 2022-10-14
 

--- a/README.md
+++ b/README.md
@@ -31,14 +31,14 @@ None of the variables below are required. When not defined by the user, the [def
 | `mariadb_configure_swappiness` | true            | When `true`, this role will set the "swappiness" value (see `mariadb_swappiness`.                            |
 | `mariadb_custom_cnf`           | {}              | Dictionary with custom configuration.                                                                        |
 | `mariadb_databases`            | []              | List of dicts specifying the databases to be added. See below for details.                                   |
-| `mariadb_mirror`               | yum.mariadb.org | Download mirror for the .rpm package (1)                                                                     |
+| `mariadb_mirror`               | null            | Download mirror for the rpm/apt package (1)                                                                     |
 | `mariadb_port`                 | 3306            | The port number used to listen to client requests                                                            |
 | `mariadb_root_password`        | ''              | The MariaDB root password. (2)                                                                               |
 | `mariadb_server_cnf`           | {}              | Dictionary with server configuration.                                                                        |
 | `mariadb_service`              | mariadb         | Name of the service (should e.g. be 'mysql' on CentOS for MariaDB 5.5)                                       |
 | `mariadb_swappiness`           | '0'             | "Swappiness" value (string). System default is 60. A value of 0 means that swapping out processes is avoided.|
 | `mariadb_users`                | []              | List of dicts specifying the users to be added. See below for details.                                       |
-| `mariadb_version`              | '10.5'          | The version of MariaDB to be installed. Default is the current stable release.                               |
+| `mariadb_version`              | '10.6'          | The version of MariaDB to be installed. Default is the current stable release.                               |
 | `mariadb_ssl_ca_crt`           | null            | Path to the certificate authority's root certificate                  |
 | `mariadb_ssl_server_crt`       | null            | Path to the server's SSL certificate                                  |
 | `mariadb_ssl_server_key`       | null            | Path to the server's SSL certificate key                                 |

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Do you use/like this role? Please consider giving it a star. If you [rate this r
 
 ## Requirements
 
-No specific requirements
+The collections `community.mysql` and `community.posix` must be installed.
 
 ## Role Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ mariadb_users: []
 mariadb_root_password: ''
 mariadb_auth_unix_plugin: false
 
-mariadb_mirror: yum.mariadb.org
+mariadb_mirror: null
 mariadb_version: '10.6'
 
 mariadb_configure_swappiness: true

--- a/tasks/add-repo.yml
+++ b/tasks/add-repo.yml
@@ -2,7 +2,7 @@
 ---
 
 - name: Add official MariaDB repository (yum)
-  template:
+  ansible.builtin.template:
     src: etc_yum.repos.d_mariadb.repo.j2
     dest: /etc/yum.repos.d/MariaDB.repo
     mode: '0644'
@@ -11,21 +11,21 @@
 
 
 - name: Install gpg to add repokey (apt)
-  package:
+  ansible.builtin.package:
     name: gpg
     state: latest
   when: ansible_distribution == 'Debian'
   tags: mariadb
 
 - name: Add official MariaDB repository key (apt)
-  apt_key:
+  ansible.builtin.apt_key:
     url: https://mariadb.org/mariadb_release_signing_key.asc
     state: present
   when: ansible_distribution == 'Debian'
   tags: mariadb
 
 - name: Add official MariaDB repository (apt)
-  template:
+  ansible.builtin.template:
     src: etc_apt_sources.list.d_mariadb.list.j2
     dest: /etc/apt/sources.list.d/mariadb.list
     mode: '0644'
@@ -33,7 +33,7 @@
   tags: mariadb
 
 - name: Update packages cache with new repo (apt)
-  apt:
+  ansible.builtin.apt:
     update_cache: true
   when: ansible_distribution == 'Debian'
   tags: mariadb

--- a/tasks/auth-unix-plugin.yml
+++ b/tasks/auth-unix-plugin.yml
@@ -3,7 +3,7 @@
 # Shell is unfortunately necessary because the mysql_user module doesn't yet
 # support plugin changes.
 - name: Enable plugin unix_socket
-  shell: >
+  ansible.builtin.shell: >
     mysql -S {{ mariadb_socket }} -u root -e
     "INSTALL PLUGIN unix_socket SONAME 'auth_socket'"
     ||
@@ -18,7 +18,7 @@
   tags: mariadb
 
 - name: Check for unix_socket in plugin column
-  shell: >
+  ansible.builtin.shell: >
     mysql -N -s -S {{ mariadb_socket }} -u root -e
     "SELECT plugin from mysql.user WHERE user = 'root'"
     ||
@@ -30,7 +30,7 @@
   tags: mariadb
 
 - name: Update root user to use unix_socket
-  shell: >
+  ansible.builtin.shell: >
     mysql -S {{ mariadb_socket }} -u root -e
     "UPDATE mysql.user SET plugin = 'unix_socket' WHERE user = 'root';
     FLUSH PRIVILEGES;"

--- a/tasks/certificates.yml
+++ b/tasks/certificates.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Create destination directory
-  file:
+  ansible.builtin.file:
     path: "{{ mariadb_config_certificates }}"
     state: directory
     mode: '750'
@@ -10,7 +10,7 @@
   tags: mariadb
 
 - name: Copy root certificate
-  copy:
+  ansible.builtin.copy:
     content: "{{ lookup('file', mariadb_ssl_ca_crt) }}"
     dest: "{{ mariadb_config_certificates }}/ca.crt"
     mode: '0644'
@@ -19,7 +19,7 @@
   tags: mariadb
 
 - name: Copy server's SSL certificate
-  copy:
+  ansible.builtin.copy:
     content: "{{ lookup('file', mariadb_ssl_server_crt) }}"
     dest: "{{ mariadb_config_certificates }}/server.crt"
     mode: '0644'
@@ -28,7 +28,7 @@
   tags: mariadb
 
 - name: Copy server's SSL certificate key
-  copy:
+  ansible.builtin.copy:
     content: "{{ lookup('file', mariadb_ssl_server_key) }}"
     dest: "{{ mariadb_config_certificates }}/server.key"
     mode: '0600'
@@ -37,7 +37,7 @@
   tags: mariadb
 
 - name: Add SSL configuration
-  blockinfile:
+  ansible.builtin.blockinfile:
     path: "{{ mariadb_config_directory }}/90-ssl.cnf"
     content: |
       [server]

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -2,7 +2,7 @@
 ---
 
 - name: Install server config file
-  template:
+  ansible.builtin.template:
     src: etc_my.cnf.d_server.cnf.j2
     dest: "{{ mariadb_config_server }}"
     mode: '0640'
@@ -12,7 +12,7 @@
   tags: mariadb
 
 - name: Install network config file
-  template:
+  ansible.builtin.template:
     src: etc_my.cnf.d_network.cnf.j2
     dest: "{{ mariadb_config_network }}"
     mode: '0640'
@@ -22,7 +22,7 @@
   tags: mariadb
 
 - name: Install custom config file
-  template:
+  ansible.builtin.template:
     src: etc_my.cnf.d_custom.cnf.j2
     dest: "{{ mariadb_config_custom }}"
     mode: '0640'
@@ -33,12 +33,12 @@
   tags: mariadb
 
 - name: Check if sysctl executable exists. If not, swappiness cannot be set!
-  stat:
+  ansible.builtin.stat:
     path: /usr/sbin/sysctl
   register: sysctl_check
 
 - name: Configure swappiness
-  sysctl:
+  ansible.posix.sysctl:
     name: vm.swappiness
     value: "{{ mariadb_swappiness }}"
     state: present
@@ -49,7 +49,7 @@
 
 # SELinux context mysqld_log_t is default for /var/log/mariadb
 - name: Create log directory
-  file:
+  ansible.builtin.file:
     state: directory
     path: /var/log/mariadb
     owner: mysql
@@ -58,7 +58,7 @@
   when: mariadb_logrotate.configure|bool
 
 - name: Configure logrotate
-  template:
+  ansible.builtin.template:
     src: etc_logrotate.d_mysql.j2
     dest: /etc/logrotate.d/mysql
     mode: '0644'
@@ -67,7 +67,7 @@
   tags: mariadb
 
 - name: Ensure service is started
-  service:
+  ansible.builtin.service:
     name: "{{ mariadb_service }}"
     state: started
     enabled: true

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -2,7 +2,7 @@
 ---
 
 - name: Remove the test database
-  mysql_db:
+  community.mysql.mysql_db:
     name: test
     login_user: root
     login_password: "{{ mariadb_root_password }}"
@@ -11,7 +11,7 @@
   tags: mariadb
 
 - name: Create user defined databases
-  mysql_db:
+  community.mysql.mysql_db:
     name: "{{ item.name }}"
     login_user: root
     login_password: "{{ mariadb_root_password }}"
@@ -28,7 +28,7 @@
 # That's not the case here, so the linter warning is ignored.
 
 - name: Copy database init scripts
-  template:  # noqa 503
+  ansible.builtin.template:  # noqa 503
     src: "{{ item.item.init_script }}"
     dest: "/tmp/{{ item.item.init_script|basename }}"
     mode: '0600'
@@ -37,7 +37,7 @@
   tags: mariadb
 
 - name: Initialise databases
-  mysql_db:  # noqa 503
+  community.mysql.mysql_db:  # noqa 503
     name: "{{ item.item.name }}"
     state: import
     target: "/tmp/{{ item.item.init_script|basename }}"
@@ -49,7 +49,7 @@
   tags: mariadb
 
 - name: Delete init scripts from the server
-  file:  # noqa 503
+  ansible.builtin.file:  # noqa 503
     name: "/tmp/{{ item.item.init_script|basename }}"
     state: absent
   with_items: "{{ db_creation.results }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,11 +2,11 @@
 ---
 
 - name: Add official MariaDB repository
-  include_tasks: add-repo.yml
+  ansible.builtin.include_tasks: add-repo.yml
   tags: mariadb
 
 - name: Create daemon group with specified gid
-  group:
+  ansible.builtin.group:
     name: "{{ mariadb_system_user.name }}"
     gid: "{{ mariadb_system_user.gid }}"
     system: true
@@ -15,7 +15,7 @@
   tags: mariadb
 
 - name: Create daemon user with specified uid
-  user:
+  ansible.builtin.user:
     name: "{{ mariadb_system_user.name }}"
     uid: "{{ mariadb_system_user.uid }}"
     system: true
@@ -27,7 +27,7 @@
   tags: mariadb
 
 - name: Install packages
-  package:
+  ansible.builtin.package:
     name: "{{ mariadb_packages }}"
     state: "{{ 'latest' if ansible_distribution == 'Debian' else 'installed' }}"
   tags: mariadb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 # roles/mariadb/tasks/main.yml
 ---
 - name: Include distribution dependent variables
-  include_vars: "{{ item }}"
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
     - "{{ ansible_distribution }}.yml"
@@ -12,15 +12,15 @@
   tags: mariadb
 
 - name: Install MariaDB
-  include_tasks: install.yml
+  ansible.builtin.include_tasks: install.yml
   tags: mariadb
 
 - name: Configure MariaDB
-  include_tasks: config.yml
+  ansible.builtin.include_tasks: config.yml
   tags: mariadb
 
 - name: Add SSL certificates
-  include_tasks: certificates.yml
+  ansible.builtin.include_tasks: certificates.yml
   when:
     - mariadb_ssl_ca_crt != None
     - mariadb_ssl_server_crt != None
@@ -28,7 +28,7 @@
   tags: mariadb
 
 - name: Authentication changes in version 10.4 message
-  debug:
+  ansible.builtin.debug:
     msg: >
       Authentication has changed in version 10.4. Both the root user and
       the user that owns the data directory (mysql by default) now utilize
@@ -41,23 +41,23 @@
   tags: mariadb
 
 - name: Set the database root password
-  include_tasks: root-password.yml
+  ansible.builtin.include_tasks: root-password.yml
   when:
     - not mariadb_auth_unix_plugin
     - mariadb_version is version('10.4', '<')
   tags: mariadb
 
 - name: Enable plugin unix_socket
-  include_tasks: auth-unix-plugin.yml
+  ansible.builtin.include_tasks: auth-unix-plugin.yml
   when:
     - mariadb_auth_unix_plugin
     - mariadb_version is version('10.4', '<')
   tags: mariadb
 
 - name: Create and initialize databases
-  include_tasks: databases.yml
+  ansible.builtin.include_tasks: databases.yml
   tags: mariadb
 
 - name: Create users
-  include_tasks: users.yml
+  ansible.builtin.include_tasks: users.yml
   tags: mariadb

--- a/tasks/root-password.yml
+++ b/tasks/root-password.yml
@@ -2,7 +2,7 @@
 ---
 
 - name: Check if a custom root password is specified
-  debug:
+  ansible.builtin.debug:
     msg: >
       Warning!! the MariaDB root password was left empty. Please set a custom
       password with role variable mariadb_root_password to secure your database
@@ -12,7 +12,7 @@
 
 # This command will exit non-zero when the root password was set previously
 - name: Check if root password is unset
-  shell: >
+  ansible.builtin.shell: >
     mysql -u root
     -p'{{ mariadb_root_password }}'
     -h localhost
@@ -25,7 +25,7 @@
 
 # Repeat runs with the same password can continue idempotently, otherwise fail.
 - name: Check if the specified root password is already set
-  shell: >
+  ansible.builtin.shell: >
     mysqladmin -u root -p{{ mariadb_root_password }} status
   changed_when: false
   no_log: true
@@ -33,7 +33,7 @@
   tags: mariadb
 
 - name: Check for previously set unix_socket in plugin column
-  command: >
+  ansible.builtin.command: >
     mysql -N -s -S {{ mariadb_socket }} -u root -e
     "SELECT plugin from mysql.user WHERE user = 'root'"
   register: plugin_root_result
@@ -42,7 +42,7 @@
   tags: mariadb
 
 - name: Set MariaDB root password for the first time (root@localhost)
-  mysql_user:
+  community.mysql.mysql_user:
     name: root
     password: "{{ mariadb_root_password }}"
     host: localhost
@@ -52,7 +52,7 @@
   tags: mariadb
 
 - name: Remove unix_socket plugin if previously set
-  command: >
+  ansible.builtin.command: >
     mysql -S {{ mariadb_socket }} -u root -e
     "UPDATE mysql.user SET plugin = '' WHERE user = 'root'; FLUSH PRIVILEGES;"
   when:
@@ -61,7 +61,7 @@
   tags: mariadb
 
 - name: Set MariaDB root password for 127.0.0.1, ::1, FQDN
-  mysql_user:
+  community.mysql.mysql_user:
     name: root
     password: "{{ mariadb_root_password }}"
     host: "{{ item }}"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -2,7 +2,7 @@
 ---
 
 - name: Remove anonymous users
-  mysql_user:
+  community.mysql.mysql_user:
     name: ''
     host_all: true
     login_user: root
@@ -13,7 +13,7 @@
   tags: mariadb
 
 - name: Create the users
-  mysql_user:
+  community.mysql.mysql_user:
     name: "{{ item.name }}"
     password: "{{ item.password }}"
     host: "{{ item.host|default('localhost') }}"

--- a/templates/etc_apt_sources.list.d_mariadb.list.j2
+++ b/templates/etc_apt_sources.list.d_mariadb.list.j2
@@ -1,4 +1,4 @@
 # MariaDB repository list - Ansible managed
 # http://downloads.mariadb.org/mariadb/repositories/
-deb [arch=amd64] http://{{ mariadb_mirror }}/{{ mariadb_version }}/debian {{ ansible_distribution_release }} main
-deb-src http://{{ mariadb_mirror }}/{{ mariadb_version }}/debian {{ ansible_distribution_release }} main
+deb [arch=amd64] http://{{ mariadb_mirror | default(_mariadb_mirror) }}/{{ mariadb_version }}/debian {{ ansible_distribution_release }} main
+deb-src http://{{ mariadb_mirror | default(_mariadb_mirror) }}/{{ mariadb_version }}/debian {{ ansible_distribution_release }} main

--- a/templates/etc_yum.repos.d_mariadb.repo.j2
+++ b/templates/etc_yum.repos.d_mariadb.repo.j2
@@ -1,5 +1,5 @@
 [MariaDB]
-baseurl = "https://{{ mariadb_mirror }}/{{ mariadb_version }}/{{ ansible_distribution|lower|regex_replace('redhat|oraclelinux|rocky|almalinux|centos', 'rhel') }}{{ ansible_distribution_major_version }}-amd64"
+baseurl = "https://{{ mariadb_mirror | default(_mariadb_mirror) }}/{{ mariadb_version }}/{{ ansible_distribution|lower|regex_replace('redhat|oraclelinux|rocky|almalinux|centos', 'rhel') }}{{ ansible_distribution_major_version }}-amd64"
 enabled = 1
 gpgcheck = 1
 gpgkey = https://yum.mariadb.org/RPM-GPG-KEY-MariaDB

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,7 +6,7 @@ mariadb_packages:
   - mariadb-server
   - python3-pymysql
 
-mariadb_mirror: mirror.mva-n.net/mariadb/repo
+_mariadb_mirror: mirror.mva-n.net/mariadb/repo
 
 mariadb_socket: /run/mysqld/mysqld.sock
 

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -6,6 +6,8 @@ mariadb_packages:
   - MariaDB-server
   - python3-PyMySQL
 
+_mariadb_mirror: yum.mariadb.org
+
 mariadb_socket: /var/lib/mysql/mysql.sock
 
 mariadb_config_directory: /etc/my.cnf.d

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -7,6 +7,8 @@ mariadb_packages:
   - MariaDB-server
   - MySQL-python
 
+_mariadb_mirror: yum.mariadb.org
+
 mariadb_socket: /var/lib/mysql/mysql.sock
 
 mariadb_config_directory: /etc/my.cnf.d

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -7,6 +7,8 @@ mariadb_packages:
   - MariaDB-server
   - python3-PyMySQL
 
+_mariadb_mirror: yum.mariadb.org
+
 mariadb_socket: /var/lib/mysql/mysql.sock
 
 mariadb_config_directory: /etc/my.cnf.d


### PR DESCRIPTION
On Debian, the default value of `yum.mariadb.org` found in `defaults/main.yml` is overridden with the `include_vars` task in `tasks/main.yml`.
This PR renames the default defined in `vars/` to `_mariadb_mirror`, and properly handles the user provided value and its fallback during the template task.

There's also a couple typos fixed.
Changelog updated adding new `3.1.4` version.
Tested on Debian Bullseye, can confirm it's properly supported by the role.

The second commit improves all tasks invocations, using their FQCNs instead of the plain role/module name.
It also defines proper requirements in the readme (likely only necessary if the user installs only `ansible-core`)

Sidenote: I'm really sorry to commit these changes literally hours after you merged and tagged the last release, hopefully there is not much to do for you other than merge and tag again. And of course feel free to ask for anything.