### PR TITLE
WIP: v3.2.0 - firewall support, fixes, improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This file adheres to the guidelines of <http://keepachangelog.com/>. Versioning 
 
 ### Changed
 
+- Use FQCNs for all tasks
 - Fix support for MariaDB mirror URL config option `mariadb_mirror`
 
 ## 3.1.3 - 2022-10-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ This file adheres to the guidelines of <http://keepachangelog.com/>. Versioning 
 
 ## 3.1.4
 
+### Added
+
+- Firewall helpers to open ports on target host using either `ufw` or `iptables` (credit: @nxet)
+
 ### Changed
 
 - Use FQCNs for all tasks

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This file contains all notable changes to the mariadb Ansible role.
 
 This file adheres to the guidelines of <http://keepachangelog.com/>. Versioning follows [Semantic Versioning](http://semver.org/).
 
-## 3.1.4
+## 3.2.0 - 2022-10-15
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file adheres to the guidelines of <http://keepachangelog.com/>. Versioning 
 
 ### Changed
 
+- Add detailed tags to all tasks
 - Use static `import_tasks` instead of dynamic `include_` to propagate tags to all children tasks
 - Use FQCNs for all tasks
 - Fix support for MariaDB mirror URL config option `mariadb_mirror`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This file adheres to the guidelines of <http://keepachangelog.com/>. Versioning 
 
 ### Changed
 
+- Use static `import_tasks` instead of dynamic `include_` to propagate tags to all children tasks
 - Use FQCNs for all tasks
 - Fix support for MariaDB mirror URL config option `mariadb_mirror`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Change log
 
-This file contains al notable changes to the mariadb Ansible role.
+This file contains all notable changes to the mariadb Ansible role.
 
 This file adheres to the guidelines of <http://keepachangelog.com/>. Versioning follows [Semantic Versioning](http://semver.org/).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This file contains all notable changes to the mariadb Ansible role.
 
 This file adheres to the guidelines of <http://keepachangelog.com/>. Versioning follows [Semantic Versioning](http://semver.org/).
 
+## 3.1.4
+
+### Changed
+
+- Fix support for MariaDB mirror URL config option `mariadb_mirror`
+
 ## 3.1.3 - 2022-10-14
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ None of the variables below are required. When not defined by the user, the [def
 | `mariadb_configure_swappiness` | true            | When `true`, this role will set the "swappiness" value (see `mariadb_swappiness`.                            |
 | `mariadb_custom_cnf`           | {}              | Dictionary with custom configuration.                                                                        |
 | `mariadb_databases`            | []              | List of dicts specifying the databases to be added. See below for details.                                   |
-| `mariadb_mirror`               | yum.mariadb.org | Download mirror for the .rpm package (1)                                                                     |
+| `mariadb_mirror`               | null            | Download mirror for the rpm/apt package (1)                                                                     |
 | `mariadb_port`                 | 3306            | The port number used to listen to client requests                                                            |
 | `mariadb_root_password`        | ''              | The MariaDB root password. (2)                                                                               |
 | `mariadb_server_cnf`           | {}              | Dictionary with server configuration.                                                                        |

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Ansible role `mariadb`
 
-An Ansible role for managing MariaDB in RedHat-based distributions. Specifically, the responsibilities of this role are to:
+An Ansible role for managing MariaDB in Debian and RedHat-based distributions. Specifically, the responsibilities of this role are to:
 
 - Install MariaDB packages from the official MariaDB repositories
 - Remove unsafe defaults:
@@ -58,6 +58,12 @@ mariadb_mirror: 'mirror.mva-n.net/mariadb/repo'
 ```
 
 (2) **It is highly recommended to set the database root password!** Leaving the password empty is a serious security risk. The role will issue a warning if the variable was not set.
+
+
+### Debian support
+
+The role is tested working on both Debian 10 `buster` and 11 `bullseye`.  
+Older versions of MariaDB might not work anymore though, and it is recommended to explicitly configure `mariadb_version` in order to target a known compatible release.
 
 ### Server configuration
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ None of the variables below are required. When not defined by the user, the [def
 | `mariadb_service`              | mariadb         | Name of the service (should e.g. be 'mysql' on CentOS for MariaDB 5.5)                                       |
 | `mariadb_swappiness`           | '0'             | "Swappiness" value (string). System default is 60. A value of 0 means that swapping out processes is avoided.|
 | `mariadb_users`                | []              | List of dicts specifying the users to be added. See below for details.                                       |
-| `mariadb_version`              | '10.5'          | The version of MariaDB to be installed. Default is the current stable release.                               |
+| `mariadb_version`              | '10.6'          | The version of MariaDB to be installed. Default is the current stable release.                               |
 | `mariadb_ssl_ca_crt`           | null            | Path to the certificate authority's root certificate                  |
 | `mariadb_ssl_server_crt`       | null            | Path to the server's SSL certificate                                  |
 | `mariadb_ssl_server_key`       | null            | Path to the server's SSL certificate key                                 |
@@ -136,7 +136,7 @@ mariadb_users:
 
 ## Dependencies
 
-No dependencies.
+The collections `community.mysql` and `community.posix` must be installed.
 
 ## Example Playbook
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,7 @@ mariadb_logrotate:
 
 mariadb_service: mariadb
 mariadb_bind_address: '127.0.0.1'
+mariadb_port: '3306'
 
 # Server configuration
 mariadb_server_cnf: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,6 +30,9 @@ mariadb_logrotate:
 mariadb_service: mariadb
 mariadb_bind_address: '127.0.0.1'
 mariadb_port: '3306'
+mariadb_firewall_backend: null
+mariadb_allowed_ips:
+  world: any
 
 # Server configuration
 mariadb_server_cnf: {}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,7 +6,7 @@ mariadb_users: []
 mariadb_root_password: ''
 mariadb_auth_unix_plugin: false
 
-mariadb_mirror: yum.mariadb.org
+mariadb_mirror: null
 mariadb_version: '10.6'
 
 mariadb_configure_swappiness: true

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,6 +16,7 @@ galaxy_info:
     - name: Debian
       versions:
         - 10
+        - 11
   galaxy_tags:
     - database
     - sql

--- a/tasks/add-repo.yml
+++ b/tasks/add-repo.yml
@@ -2,7 +2,7 @@
 ---
 
 - name: Add official MariaDB repository (yum)
-  template:
+  ansible.builtin.template:
     src: etc_yum.repos.d_mariadb.repo.j2
     dest: /etc/yum.repos.d/MariaDB.repo
     mode: '0644'
@@ -11,21 +11,21 @@
 
 
 - name: Install gpg to add repokey (apt)
-  package:
+  ansible.builtin.package:
     name: gpg
     state: latest
   when: ansible_distribution == 'Debian'
   tags: mariadb
 
 - name: Add official MariaDB repository key (apt)
-  apt_key:
+  ansible.builtin.apt_key:
     url: https://mariadb.org/mariadb_release_signing_key.asc
     state: present
   when: ansible_distribution == 'Debian'
   tags: mariadb
 
 - name: Add official MariaDB repository (apt)
-  template:
+  ansible.builtin.template:
     src: etc_apt_sources.list.d_mariadb.list.j2
     dest: /etc/apt/sources.list.d/mariadb.list
     mode: '0644'
@@ -33,7 +33,7 @@
   tags: mariadb
 
 - name: Update packages cache with new repo (apt)
-  apt:
+  ansible.builtin.apt:
     update_cache: true
   when: ansible_distribution == 'Debian'
   tags: mariadb

--- a/tasks/add-repo.yml
+++ b/tasks/add-repo.yml
@@ -7,33 +7,30 @@
     dest: /etc/yum.repos.d/MariaDB.repo
     mode: '0644'
   when: ansible_distribution != 'Debian'
-  tags: mariadb
+  tags: mariadb-repo-yum
 
 
-- name: Install gpg to add repokey (apt)
-  ansible.builtin.package:
-    name: gpg
-    state: latest
+- name: Run Debian-specific tasks
   when: ansible_distribution == 'Debian'
-  tags: mariadb
+  tags: mariadb-repo-apt
+  block:
 
-- name: Add official MariaDB repository key (apt)
-  ansible.builtin.apt_key:
-    url: https://mariadb.org/mariadb_release_signing_key.asc
-    state: present
-  when: ansible_distribution == 'Debian'
-  tags: mariadb
+  - name: Install gpg to add repokey (apt)
+    ansible.builtin.package:
+      name: gpg
+      state: latest
 
-- name: Add official MariaDB repository (apt)
-  ansible.builtin.template:
-    src: etc_apt_sources.list.d_mariadb.list.j2
-    dest: /etc/apt/sources.list.d/mariadb.list
-    mode: '0644'
-  when: ansible_distribution == 'Debian'
-  tags: mariadb
+  - name: Add official MariaDB repository key (apt)
+    ansible.builtin.apt_key:
+      url: https://mariadb.org/mariadb_release_signing_key.asc
+      state: present
 
-- name: Update packages cache with new repo (apt)
-  ansible.builtin.apt:
-    update_cache: true
-  when: ansible_distribution == 'Debian'
-  tags: mariadb
+  - name: Add official MariaDB repository (apt)
+    ansible.builtin.template:
+      src: etc_apt_sources.list.d_mariadb.list.j2
+      dest: /etc/apt/sources.list.d/mariadb.list
+      mode: '0644'
+
+  - name: Update packages cache with new repo (apt)
+    ansible.builtin.apt:
+      update_cache: true

--- a/tasks/auth-unix-plugin.yml
+++ b/tasks/auth-unix-plugin.yml
@@ -3,7 +3,7 @@
 # Shell is unfortunately necessary because the mysql_user module doesn't yet
 # support plugin changes.
 - name: Enable plugin unix_socket
-  shell: >
+  ansible.builtin.shell: >
     mysql -S {{ mariadb_socket }} -u root -e
     "INSTALL PLUGIN unix_socket SONAME 'auth_socket'"
     ||
@@ -18,7 +18,7 @@
   tags: mariadb
 
 - name: Check for unix_socket in plugin column
-  shell: >
+  ansible.builtin.shell: >
     mysql -N -s -S {{ mariadb_socket }} -u root -e
     "SELECT plugin from mysql.user WHERE user = 'root'"
     ||
@@ -30,7 +30,7 @@
   tags: mariadb
 
 - name: Update root user to use unix_socket
-  shell: >
+  ansible.builtin.shell: >
     mysql -S {{ mariadb_socket }} -u root -e
     "UPDATE mysql.user SET plugin = 'unix_socket' WHERE user = 'root';
     FLUSH PRIVILEGES;"

--- a/tasks/auth-unix-plugin.yml
+++ b/tasks/auth-unix-plugin.yml
@@ -15,7 +15,7 @@
     - plugin_install_result.rc != 0
     - 'already installed' not in plugin_install_result.stderr
   no_log: true
-  tags: mariadb
+  tags: mariadb-authunix-enable
 
 - name: Check for unix_socket in plugin column
   ansible.builtin.shell: >
@@ -27,7 +27,7 @@
   register: plugin_root_result
   changed_when: plugin_root_result.stdout is not search('unix_socket')
   no_log: true
-  tags: mariadb
+  tags: mariadb-authunix-check
 
 - name: Update root user to use unix_socket
   ansible.builtin.shell: >
@@ -40,4 +40,4 @@
     FLUSH PRIVILEGES;"
   when: plugin_root_result.stdout is not search('unix_socket')
   no_log: true
-  tags: mariadb
+  tags: mariadb-authunix-config

--- a/tasks/certificates.yml
+++ b/tasks/certificates.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Create destination directory
-  file:
+  ansible.builtin.file:
     path: "{{ mariadb_config_certificates }}"
     state: directory
     mode: '750'
@@ -10,7 +10,7 @@
   tags: mariadb
 
 - name: Copy root certificate
-  copy:
+  ansible.builtin.copy:
     content: "{{ lookup('file', mariadb_ssl_ca_crt) }}"
     dest: "{{ mariadb_config_certificates }}/ca.crt"
     mode: '0644'
@@ -19,7 +19,7 @@
   tags: mariadb
 
 - name: Copy server's SSL certificate
-  copy:
+  ansible.builtin.copy:
     content: "{{ lookup('file', mariadb_ssl_server_crt) }}"
     dest: "{{ mariadb_config_certificates }}/server.crt"
     mode: '0644'
@@ -28,7 +28,7 @@
   tags: mariadb
 
 - name: Copy server's SSL certificate key
-  copy:
+  ansible.builtin.copy:
     content: "{{ lookup('file', mariadb_ssl_server_key) }}"
     dest: "{{ mariadb_config_certificates }}/server.key"
     mode: '0600'
@@ -37,7 +37,7 @@
   tags: mariadb
 
 - name: Add SSL configuration
-  blockinfile:
+  ansible.builtin.blockinfile:
     path: "{{ mariadb_config_directory }}/90-ssl.cnf"
     content: |
       [server]

--- a/tasks/certificates.yml
+++ b/tasks/certificates.yml
@@ -7,7 +7,7 @@
     mode: '750'
     owner: "{{ mariadb_system_user.uid }}"
     group: "{{ mariadb_system_user.gid }}"
-  tags: mariadb
+  tags: mariadb-ssl-copy
 
 - name: Copy root certificate
   ansible.builtin.copy:
@@ -16,7 +16,7 @@
     mode: '0644'
     owner: "{{ mariadb_system_user.uid }}"
     group: "{{ mariadb_system_user.gid }}"
-  tags: mariadb
+  tags: mariadb-ssl-copy
 
 - name: Copy server's SSL certificate
   ansible.builtin.copy:
@@ -25,7 +25,7 @@
     mode: '0644'
     owner: "{{ mariadb_system_user.uid }}"
     group: "{{ mariadb_system_user.gid }}"
-  tags: mariadb
+  tags: mariadb-ssl-copy
 
 - name: Copy server's SSL certificate key
   ansible.builtin.copy:
@@ -34,7 +34,7 @@
     mode: '0600'
     owner: "{{ mariadb_system_user.uid }}"
     group: "{{ mariadb_system_user.gid }}"
-  tags: mariadb
+  tags: mariadb-ssl-copy
 
 - name: Add SSL configuration
   ansible.builtin.blockinfile:
@@ -50,4 +50,4 @@
     owner: "{{ mariadb_system_user.uid }}"
     group: "{{ mariadb_system_user.gid }}"
   notify: restart mariadb
-  tags: mariadb
+  tags: mariadb-ssl-config

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -9,7 +9,7 @@
     owner: "{{ mariadb_system_user.uid }}"
     group: "{{ mariadb_system_user.gid }}"
   notify: restart mariadb
-  tags: mariadb
+  tags: mariadb-config-server
 
 - name: Install network config file
   ansible.builtin.template:
@@ -19,7 +19,7 @@
     owner: "{{ mariadb_system_user.uid }}"
     group: "{{ mariadb_system_user.gid }}"
   notify: restart mariadb
-  tags: mariadb
+  tags: mariadb-config-network
 
 - name: Install custom config file
   ansible.builtin.template:
@@ -30,12 +30,13 @@
     group: "{{ mariadb_system_user.gid }}"
   when: mariadb_custom_cnf|length != 0
   notify: restart mariadb
-  tags: mariadb
+  tags: mariadb-config-custom
 
 - name: Check if sysctl executable exists. If not, swappiness cannot be set!
   ansible.builtin.stat:
     path: /usr/sbin/sysctl
   register: sysctl_check
+  tags: mariadb-config-swappiness
 
 - name: Configure swappiness
   ansible.posix.sysctl:
@@ -45,7 +46,7 @@
   when:
     - mariadb_configure_swappiness|bool
     - sysctl_check.stat.exists
-  tags: mariadb
+  tags: mariadb-config-swappiness
 
 # SELinux context mysqld_log_t is default for /var/log/mariadb
 - name: Create log directory
@@ -56,6 +57,7 @@
     group: mysql
     mode: '0755'
   when: mariadb_logrotate.configure|bool
+  tags: mariadb-config-logs
 
 - name: Configure logrotate
   ansible.builtin.template:
@@ -64,11 +66,11 @@
     mode: '0644'
   when: mariadb_logrotate.configure|bool
   notify: restart mariadb
-  tags: mariadb
+  tags: mariadb-config-logrotate
 
 - name: Ensure service is started
   ansible.builtin.service:
     name: "{{ mariadb_service }}"
     state: started
     enabled: true
-  tags: mariadb
+  tags: mariadb-config-service

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -2,7 +2,7 @@
 ---
 
 - name: Install server config file
-  template:
+  ansible.builtin.template:
     src: etc_my.cnf.d_server.cnf.j2
     dest: "{{ mariadb_config_server }}"
     mode: '0640'
@@ -12,7 +12,7 @@
   tags: mariadb
 
 - name: Install network config file
-  template:
+  ansible.builtin.template:
     src: etc_my.cnf.d_network.cnf.j2
     dest: "{{ mariadb_config_network }}"
     mode: '0640'
@@ -22,7 +22,7 @@
   tags: mariadb
 
 - name: Install custom config file
-  template:
+  ansible.builtin.template:
     src: etc_my.cnf.d_custom.cnf.j2
     dest: "{{ mariadb_config_custom }}"
     mode: '0640'
@@ -33,12 +33,12 @@
   tags: mariadb
 
 - name: Check if sysctl executable exists. If not, swappiness cannot be set!
-  stat:
+  ansible.builtin.stat:
     path: /usr/sbin/sysctl
   register: sysctl_check
 
 - name: Configure swappiness
-  sysctl:
+  ansible.posix.sysctl:
     name: vm.swappiness
     value: "{{ mariadb_swappiness }}"
     state: present
@@ -49,7 +49,7 @@
 
 # SELinux context mysqld_log_t is default for /var/log/mariadb
 - name: Create log directory
-  file:
+  ansible.builtin.file:
     state: directory
     path: /var/log/mariadb
     owner: mysql
@@ -58,7 +58,7 @@
   when: mariadb_logrotate.configure|bool
 
 - name: Configure logrotate
-  template:
+  ansible.builtin.template:
     src: etc_logrotate.d_mysql.j2
     dest: /etc/logrotate.d/mysql
     mode: '0644'
@@ -67,7 +67,7 @@
   tags: mariadb
 
 - name: Ensure service is started
-  service:
+  ansible.builtin.service:
     name: "{{ mariadb_service }}"
     state: started
     enabled: true

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -2,7 +2,7 @@
 ---
 
 - name: Remove the test database
-  mysql_db:
+  community.mysql.mysql_db:
     name: test
     login_user: root
     login_password: "{{ mariadb_root_password }}"
@@ -11,7 +11,7 @@
   tags: mariadb
 
 - name: Create user defined databases
-  mysql_db:
+  community.mysql.mysql_db:
     name: "{{ item.name }}"
     login_user: root
     login_password: "{{ mariadb_root_password }}"
@@ -28,7 +28,7 @@
 # That's not the case here, so the linter warning is ignored.
 
 - name: Copy database init scripts
-  template:  # noqa 503
+  ansible.builtin.template:  # noqa 503
     src: "{{ item.item.init_script }}"
     dest: "/tmp/{{ item.item.init_script|basename }}"
     mode: '0600'
@@ -37,7 +37,7 @@
   tags: mariadb
 
 - name: Initialise databases
-  mysql_db:  # noqa 503
+  community.mysql.mysql_db:  # noqa 503
     name: "{{ item.item.name }}"
     state: import
     target: "/tmp/{{ item.item.init_script|basename }}"
@@ -49,7 +49,7 @@
   tags: mariadb
 
 - name: Delete init scripts from the server
-  file:  # noqa 503
+  ansible.builtin.file:  # noqa 503
     name: "/tmp/{{ item.item.init_script|basename }}"
     state: absent
   with_items: "{{ db_creation.results }}"

--- a/tasks/databases.yml
+++ b/tasks/databases.yml
@@ -8,7 +8,7 @@
     login_password: "{{ mariadb_root_password }}"
     login_unix_socket: "{{ mariadb_socket }}"
     state: absent
-  tags: mariadb
+  tags: mariadb-databases-cleanup
 
 - name: Create user defined databases
   community.mysql.mysql_db:
@@ -19,7 +19,7 @@
     state: present
   with_items: "{{ mariadb_databases }}"
   register: db_creation
-  tags: mariadb
+  tags: mariadb-databases-create
 
 # Below, the databases are initialised, but only when the database was created
 # in the previous step. This ensures idempotence.
@@ -34,7 +34,7 @@
     mode: '0600'
   with_items: "{{ db_creation.results }}"
   when: item.changed and item.item.init_script is defined
-  tags: mariadb
+  tags: mariadb-databases-init, mariadb-databases-scripts
 
 - name: Initialise databases
   community.mysql.mysql_db:  # noqa 503
@@ -46,7 +46,7 @@
     login_unix_socket: "{{ mariadb_socket }}"
   with_items: "{{ db_creation.results }}"
   when: item.changed and item.item.init_script is defined
-  tags: mariadb
+  tags: mariadb-databases-init
 
 - name: Delete init scripts from the server
   ansible.builtin.file:  # noqa 503
@@ -54,4 +54,4 @@
     state: absent
   with_items: "{{ db_creation.results }}"
   when: item.changed and item.item.init_script is defined
-  tags: mariadb
+  tags: mariadb-databases-init, mariadb-databases-scripts-cleanup

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -10,7 +10,7 @@
     proto: tcp
     comment: "mariadb-{{ item.key }}"
   loop: "{{ mariadb_allowed_ips | dict2items }}"
-  tags: mariadb
+  tags: mariadb-firewall-ufw
 
 - name: Firewall - Open MariaDB port (iptables)
   when: mariadb_firewall_backend == 'iptables'
@@ -22,6 +22,6 @@
     comment: "mariadb-{{ item.key }}"
     jump: ACCEPT
   loop: "{{ mariadb_allowed_ips | dict2items }}"
-  tags: mariadb
+  tags: mariadb-firewall-iptables
 
 ...

--- a/tasks/firewall.yml
+++ b/tasks/firewall.yml
@@ -1,0 +1,27 @@
+---
+
+- name: Firewall - Open MariaDB port (ufw)
+  when: mariadb_firewall_backend == 'ufw'
+  community.general.ufw:
+    rule: allow
+    direction: in
+    from_ip: "{{ item.value }}"
+    to_port: "{{ mariadb_port }}"
+    proto: tcp
+    comment: "mariadb-{{ item.key }}"
+  loop: "{{ mariadb_allowed_ips | dict2items }}"
+  tags: mariadb
+
+- name: Firewall - Open MariaDB port (iptables)
+  when: mariadb_firewall_backend == 'iptables'
+  ansible.builtin.iptables:
+    chain: INPUT
+    source: "{{ item.value }}"
+    destination_port: "{{ mariadb_port }}"
+    protocol: tcp
+    comment: "mariadb-{{ item.key }}"
+    jump: ACCEPT
+  loop: "{{ mariadb_allowed_ips | dict2items }}"
+  tags: mariadb
+
+...

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,8 +1,8 @@
 # roles/mariadb/tasks/install.yml
 ---
 
-- name: Add official MariaDB repository
-  ansible.builtin.include_tasks: add-repo.yml
+- name: Import tasks to add official MariaDB repository
+  ansible.builtin.import_tasks: add-repo.yml
   tags: mariadb
 
 - name: Create daemon group with specified gid

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -2,11 +2,11 @@
 ---
 
 - name: Add official MariaDB repository
-  include_tasks: add-repo.yml
+  ansible.builtin.include_tasks: add-repo.yml
   tags: mariadb
 
 - name: Create daemon group with specified gid
-  group:
+  ansible.builtin.group:
     name: "{{ mariadb_system_user.name }}"
     gid: "{{ mariadb_system_user.gid }}"
     system: true
@@ -15,7 +15,7 @@
   tags: mariadb
 
 - name: Create daemon user with specified uid
-  user:
+  ansible.builtin.user:
     name: "{{ mariadb_system_user.name }}"
     uid: "{{ mariadb_system_user.uid }}"
     system: true
@@ -27,7 +27,7 @@
   tags: mariadb
 
 - name: Install packages
-  package:
+  ansible.builtin.package:
     name: "{{ mariadb_packages }}"
     state: "{{ 'latest' if ansible_distribution == 'Debian' else 'installed' }}"
   tags: mariadb

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,7 +3,7 @@
 
 - name: Import tasks to add official MariaDB repository
   ansible.builtin.import_tasks: add-repo.yml
-  tags: mariadb
+  tags: mariadb-repo
 
 - name: Create daemon group with specified gid
   ansible.builtin.group:
@@ -12,7 +12,7 @@
     system: true
     state: present
     non_unique: true # necessary on Debian
-  tags: mariadb
+  tags: mariadb-install-user
 
 - name: Create daemon user with specified uid
   ansible.builtin.user:
@@ -24,10 +24,10 @@
     home: "{{ mariadb_system_user.home }}"
     create_home: false
     shell: "{{ mariadb_system_user.shell }}"
-  tags: mariadb
+  tags: mariadb-install-user
 
 - name: Install packages
   ansible.builtin.package:
     name: "{{ mariadb_packages }}"
     state: "{{ 'latest' if ansible_distribution == 'Debian' else 'installed' }}"
-  tags: mariadb
+  tags: mariadb-install-pkg

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,3 +61,8 @@
 - name: Create users
   ansible.builtin.include_tasks: users.yml
   tags: mariadb
+
+- name: Open firewall port
+  when: mariadb_firewall_backend != None
+  ansible.builtin.include_tasks: firewall.yml
+  tags: mariadb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 # roles/mariadb/tasks/main.yml
 ---
 - name: Include distribution dependent variables
-  include_vars: "{{ item }}"
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
     - "{{ ansible_distribution }}.yml"
@@ -12,15 +12,15 @@
   tags: mariadb
 
 - name: Install MariaDB
-  include_tasks: install.yml
+  ansible.builtin.include_tasks: install.yml
   tags: mariadb
 
 - name: Configure MariaDB
-  include_tasks: config.yml
+  ansible.builtin.include_tasks: config.yml
   tags: mariadb
 
 - name: Add SSL certificates
-  include_tasks: certificates.yml
+  ansible.builtin.include_tasks: certificates.yml
   when:
     - mariadb_ssl_ca_crt != None
     - mariadb_ssl_server_crt != None
@@ -28,7 +28,7 @@
   tags: mariadb
 
 - name: Authentication changes in version 10.4 message
-  debug:
+  ansible.builtin.debug:
     msg: >
       Authentication has changed in version 10.4. Both the root user and
       the user that owns the data directory (mysql by default) now utilize
@@ -41,23 +41,23 @@
   tags: mariadb
 
 - name: Set the database root password
-  include_tasks: root-password.yml
+  ansible.builtin.include_tasks: root-password.yml
   when:
     - not mariadb_auth_unix_plugin
     - mariadb_version is version('10.4', '<')
   tags: mariadb
 
 - name: Enable plugin unix_socket
-  include_tasks: auth-unix-plugin.yml
+  ansible.builtin.include_tasks: auth-unix-plugin.yml
   when:
     - mariadb_auth_unix_plugin
     - mariadb_version is version('10.4', '<')
   tags: mariadb
 
 - name: Create and initialize databases
-  include_tasks: databases.yml
+  ansible.builtin.include_tasks: databases.yml
   tags: mariadb
 
 - name: Create users
-  include_tasks: users.yml
+  ansible.builtin.include_tasks: users.yml
   tags: mariadb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,16 +11,16 @@
     - "{{ ansible_distribution_file_variety }}.yml"
   tags: mariadb
 
-- name: Install MariaDB
-  ansible.builtin.include_tasks: install.yml
+- name: Import tasks to Install MariaDB
+  ansible.builtin.import_tasks: install.yml
   tags: mariadb
 
-- name: Configure MariaDB
-  ansible.builtin.include_tasks: config.yml
+- name: Import tasks to Configure MariaDB
+  ansible.builtin.import_tasks: config.yml
   tags: mariadb
 
-- name: Add SSL certificates
-  ansible.builtin.include_tasks: certificates.yml
+- name: Import tasks to Add SSL certificates
+  ansible.builtin.import_tasks: certificates.yml
   when:
     - mariadb_ssl_ca_crt != None
     - mariadb_ssl_server_crt != None
@@ -40,29 +40,29 @@
   when: mariadb_version is version('10.4', '>=')
   tags: mariadb
 
-- name: Set the database root password
-  ansible.builtin.include_tasks: root-password.yml
+- name: Import tasks to Set the database root password
+  ansible.builtin.import_tasks: root-password.yml
   when:
     - not mariadb_auth_unix_plugin
     - mariadb_version is version('10.4', '<')
   tags: mariadb
 
-- name: Enable plugin unix_socket
-  ansible.builtin.include_tasks: auth-unix-plugin.yml
+- name: Import tasks to Enable plugin unix_socket
+  ansible.builtin.import_tasks: auth-unix-plugin.yml
   when:
     - mariadb_auth_unix_plugin
     - mariadb_version is version('10.4', '<')
   tags: mariadb
 
-- name: Create and initialize databases
-  ansible.builtin.include_tasks: databases.yml
+- name: Import tasks to Create and initialize databases
+  ansible.builtin.import_tasks: databases.yml
   tags: mariadb
 
-- name: Create users
-  ansible.builtin.include_tasks: users.yml
+- name: Import tasks to Create users
+  ansible.builtin.import_tasks: users.yml
   tags: mariadb
 
-- name: Open firewall port
+- name: Import tasks to Open firewall port
   when: mariadb_firewall_backend != None
-  ansible.builtin.include_tasks: firewall.yml
+  ansible.builtin.import_tasks: firewall.yml
   tags: mariadb

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,11 +13,11 @@
 
 - name: Import tasks to Install MariaDB
   ansible.builtin.import_tasks: install.yml
-  tags: mariadb
+  tags: mariadb, mariadb-install
 
 - name: Import tasks to Configure MariaDB
   ansible.builtin.import_tasks: config.yml
-  tags: mariadb
+  tags: mariadb, mariadb-config
 
 - name: Import tasks to Add SSL certificates
   ansible.builtin.import_tasks: certificates.yml
@@ -25,7 +25,7 @@
     - mariadb_ssl_ca_crt != None
     - mariadb_ssl_server_crt != None
     - mariadb_ssl_server_key != None
-  tags: mariadb
+  tags: mariadb, mariadb-config, mariadb-ssl
 
 - name: Authentication changes in version 10.4 message
   ansible.builtin.debug:
@@ -45,24 +45,24 @@
   when:
     - not mariadb_auth_unix_plugin
     - mariadb_version is version('10.4', '<')
-  tags: mariadb
+  tags: mariadb, mariadb-config, mariadb-rootpwd
 
 - name: Import tasks to Enable plugin unix_socket
   ansible.builtin.import_tasks: auth-unix-plugin.yml
   when:
     - mariadb_auth_unix_plugin
     - mariadb_version is version('10.4', '<')
-  tags: mariadb
+  tags: mariadb, mariadb-config, mariadb-authunix
 
 - name: Import tasks to Create and initialize databases
   ansible.builtin.import_tasks: databases.yml
-  tags: mariadb
+  tags: mariadb, mariadb-init, mariadb-databases
 
 - name: Import tasks to Create users
   ansible.builtin.import_tasks: users.yml
-  tags: mariadb
+  tags: mariadb, mariadb-init, mariadb-users
 
 - name: Import tasks to Open firewall port
   when: mariadb_firewall_backend != None
   ansible.builtin.import_tasks: firewall.yml
-  tags: mariadb
+  tags: mariadb, mariadb-firewall

--- a/tasks/root-password.yml
+++ b/tasks/root-password.yml
@@ -2,7 +2,7 @@
 ---
 
 - name: Check if a custom root password is specified
-  debug:
+  ansible.builtin.debug:
     msg: >
       Warning!! the MariaDB root password was left empty. Please set a custom
       password with role variable mariadb_root_password to secure your database
@@ -12,7 +12,7 @@
 
 # This command will exit non-zero when the root password was set previously
 - name: Check if root password is unset
-  shell: >
+  ansible.builtin.shell: >
     mysql -u root
     -p'{{ mariadb_root_password }}'
     -h localhost
@@ -25,7 +25,7 @@
 
 # Repeat runs with the same password can continue idempotently, otherwise fail.
 - name: Check if the specified root password is already set
-  shell: >
+  ansible.builtin.shell: >
     mysqladmin -u root -p{{ mariadb_root_password }} status
   changed_when: false
   no_log: true
@@ -33,7 +33,7 @@
   tags: mariadb
 
 - name: Check for previously set unix_socket in plugin column
-  command: >
+  ansible.builtin.command: >
     mysql -N -s -S {{ mariadb_socket }} -u root -e
     "SELECT plugin from mysql.user WHERE user = 'root'"
   register: plugin_root_result
@@ -42,7 +42,7 @@
   tags: mariadb
 
 - name: Set MariaDB root password for the first time (root@localhost)
-  mysql_user:
+  community.mysql.mysql_user:
     name: root
     password: "{{ mariadb_root_password }}"
     host: localhost
@@ -52,7 +52,7 @@
   tags: mariadb
 
 - name: Remove unix_socket plugin if previously set
-  command: >
+  ansible.builtin.command: >
     mysql -S {{ mariadb_socket }} -u root -e
     "UPDATE mysql.user SET plugin = '' WHERE user = 'root'; FLUSH PRIVILEGES;"
   when:
@@ -61,7 +61,7 @@
   tags: mariadb
 
 - name: Set MariaDB root password for 127.0.0.1, ::1, FQDN
-  mysql_user:
+  community.mysql.mysql_user:
     name: root
     password: "{{ mariadb_root_password }}"
     host: "{{ item }}"

--- a/tasks/root-password.yml
+++ b/tasks/root-password.yml
@@ -8,7 +8,7 @@
       password with role variable mariadb_root_password to secure your database
       server!
   when: not mariadb_root_password
-  tags: mariadb
+  tags: mariadb-rootpwd-check
 
 # This command will exit non-zero when the root password was set previously
 - name: Check if root password is unset
@@ -21,7 +21,7 @@
   changed_when: false
   ignore_errors: true
   register: root_pwd_check
-  tags: mariadb
+  tags: mariadb-rootpwd-check
 
 # Repeat runs with the same password can continue idempotently, otherwise fail.
 - name: Check if the specified root password is already set
@@ -30,7 +30,7 @@
   changed_when: false
   no_log: true
   when: root_pwd_check.rc != 0
-  tags: mariadb
+  tags: mariadb-rootpwd-check
 
 - name: Check for previously set unix_socket in plugin column
   ansible.builtin.command: >
@@ -39,7 +39,7 @@
   register: plugin_root_result
   changed_when: plugin_root_result.stdout is search('unix_socket')
   when: root_pwd_check.rc == 0
-  tags: mariadb
+  tags: mariadb-rootpwd-check
 
 - name: Set MariaDB root password for the first time (root@localhost)
   community.mysql.mysql_user:
@@ -49,7 +49,7 @@
     login_unix_socket: "{{ mariadb_socket }}"
     state: present
   when: root_pwd_check.rc != 0
-  tags: mariadb
+  tags: mariadb-rootpwd-set-localhost
 
 - name: Remove unix_socket plugin if previously set
   ansible.builtin.command: >
@@ -58,7 +58,7 @@
   when:
     - root_pwd_check.rc == 0
     - plugin_root_result.stdout is search('unix_socket')
-  tags: mariadb
+  tags: mariadb-rootpwd-cleanup
 
 - name: Set MariaDB root password for 127.0.0.1, ::1, FQDN
   community.mysql.mysql_user:
@@ -74,4 +74,4 @@
     - 127.0.0.1
     - "{{ ansible_fqdn }}"
   when: root_pwd_check.rc == 0
-  tags: mariadb
+  tags: mariadb-rootpwd-set-local

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -2,7 +2,7 @@
 ---
 
 - name: Remove anonymous users
-  mysql_user:
+  community.mysql.mysql_user:
     name: ''
     host_all: true
     login_user: root
@@ -13,7 +13,7 @@
   tags: mariadb
 
 - name: Create the users
-  mysql_user:
+  community.mysql.mysql_user:
     name: "{{ item.name }}"
     password: "{{ item.password }}"
     host: "{{ item.host|default('localhost') }}"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -10,7 +10,7 @@
     login_unix_socket: "{{ mariadb_socket }}"
     state: absent
   no_log: true
-  tags: mariadb
+  tags: mariadb-users-anon
 
 - name: Create the users
   community.mysql.mysql_user:
@@ -25,4 +25,4 @@
     state: present
   no_log: true
   with_items: "{{ mariadb_users }}"
-  tags: mariadb
+  tags: mariadb-users-create

--- a/templates/etc_apt_sources.list.d_mariadb.list.j2
+++ b/templates/etc_apt_sources.list.d_mariadb.list.j2
@@ -1,4 +1,4 @@
 # MariaDB repository list - Ansible managed
 # http://downloads.mariadb.org/mariadb/repositories/
-deb [arch=amd64] http://{{ mariadb_mirror }}/{{ mariadb_version }}/debian {{ ansible_distribution_release }} main
-deb-src http://{{ mariadb_mirror }}/{{ mariadb_version }}/debian {{ ansible_distribution_release }} main
+deb [arch=amd64] http://{{ mariadb_mirror | default(_mariadb_mirror) }}/{{ mariadb_version }}/debian {{ ansible_distribution_release }} main
+deb-src http://{{ mariadb_mirror | default(_mariadb_mirror) }}/{{ mariadb_version }}/debian {{ ansible_distribution_release }} main

--- a/templates/etc_yum.repos.d_mariadb.repo.j2
+++ b/templates/etc_yum.repos.d_mariadb.repo.j2
@@ -1,5 +1,5 @@
 [MariaDB]
-baseurl = "https://{{ mariadb_mirror }}/{{ mariadb_version }}/{{ ansible_distribution|lower|regex_replace('redhat|oraclelinux|rocky|almalinux|centos', 'rhel') }}{{ ansible_distribution_major_version }}-amd64"
+baseurl = "https://{{ mariadb_mirror | default(_mariadb_mirror) }}/{{ mariadb_version }}/{{ ansible_distribution|lower|regex_replace('redhat|oraclelinux|rocky|almalinux|centos', 'rhel') }}{{ ansible_distribution_major_version }}-amd64"
 enabled = 1
 gpgcheck = 1
 gpgkey = https://yum.mariadb.org/RPM-GPG-KEY-MariaDB

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,7 +6,7 @@ mariadb_packages:
   - mariadb-server
   - python3-pymysql
 
-mariadb_mirror: mirror.mva-n.net/mariadb/repo
+_mariadb_mirror: mirror.mva-n.net/mariadb/repo
 
 mariadb_socket: /run/mysqld/mysqld.sock
 

--- a/vars/Fedora.yml
+++ b/vars/Fedora.yml
@@ -6,6 +6,8 @@ mariadb_packages:
   - MariaDB-server
   - python3-PyMySQL
 
+_mariadb_mirror: yum.mariadb.org
+
 mariadb_socket: /var/lib/mysql/mysql.sock
 
 mariadb_config_directory: /etc/my.cnf.d

--- a/vars/RedHat-7.yml
+++ b/vars/RedHat-7.yml
@@ -7,6 +7,8 @@ mariadb_packages:
   - MariaDB-server
   - MySQL-python
 
+_mariadb_mirror: yum.mariadb.org
+
 mariadb_socket: /var/lib/mysql/mysql.sock
 
 mariadb_config_directory: /etc/my.cnf.d

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -7,6 +7,8 @@ mariadb_packages:
   - MariaDB-server
   - python3-PyMySQL
 
+_mariadb_mirror: yum.mariadb.org
+
 mariadb_socket: /var/lib/mysql/mysql.sock
 
 mariadb_config_directory: /etc/my.cnf.d


### PR DESCRIPTION
This PR replaces #60, adding more improvements and support for firewall configuration.

- [fix] add `mariadb_port` default value in `defaults/main.yml`, commit 9a9a44df69ed4e011735b31dc22a322ed1ca41db
- [fix] list dependencies in `README` (probably only useful for users which only installed `ansible-core`), commit 9a9a44df69ed4e011735b31dc22a322ed1ca41db
- [fix] actually use `mariadb_mirror` config option (see #60 for more info), commit f181dd18423bfee8dd48cfe2190e70b06655c72c
- [fix] use static `import_tasks` instead of dynamic `include_` (to propagate tags to all children tasks), commit 98960906c693c327d6f7a95736092a5775120b07
- [fix] updated all tasks to use FQCNs instead of base role/module names, commit d1b9834d9ef8855ad5db2116fcd05753394604bc
- [feat] firewall tasks to open ports, commit f20c402f514225614e9db989da15a2f73f9285ba
- [feat] detailed tags to all tasks, commit 9689311b9cd492486e80fc57f9fda12d340d1c8f

The changelog has been updated with all notable changes, alongside with a new version header (using placeholder date of today).

I would *really* appreciate the commit history being preserved, instead of squashing on merge.
And of course I'm looking forward to discuss in detail any of my proposed changes if required.