### PR TITLE
Add support for encrypted user passwords

### DIFF
--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -16,6 +16,7 @@
   mysql_user:
     name: "{{ item.name }}"
     password: "{{ item.password }}"
+    encrypted: "{{ item.encrypted }}"
     host: "{{ item.host|default('localhost') }}"
     priv: "{{ item.priv }}"
     append_privs: "{{ item.append_privs|default('no') }}"

--- a/tasks/users.yml
+++ b/tasks/users.yml
@@ -16,7 +16,7 @@
   mysql_user:
     name: "{{ item.name }}"
     password: "{{ item.password }}"
-    encrypted: "{{ item.encrypted }}"
+    encrypted: "{{ item.encrypted|default('no') }}"
     host: "{{ item.host|default('localhost') }}"
     priv: "{{ item.priv }}"
     append_privs: "{{ item.append_privs|default('no') }}"


### PR DESCRIPTION
This PR adds the parameter `encrypted` to the user creation task and gives it a default value of `no`.
Enabling `encypted` gives the user the option to provide a password in the form of a `mysql_native_password` hash.