### PR TITLE
Add support for multiline `ansible_managed`

### DIFF
--- a/templates/etc_logrotate.d_mysql.j2
+++ b/templates/etc_logrotate.d_mysql.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 # This logname can be set in /etc/{{ 'mysql/' if ansible_distribution == 'Debian' else '' }}my.cnf
 # by setting the variable "log-error"

--- a/templates/etc_my.cnf.d_custom.cnf.j2
+++ b/templates/etc_my.cnf.d_custom.cnf.j2
@@ -1,6 +1,5 @@
 # MariaDB Custom server configuration
-#
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 {% for section_name, section_contents in mariadb_custom_cnf.items() %}
 [{{ section_name }}]

--- a/templates/etc_my.cnf.d_network.cnf.j2
+++ b/templates/etc_my.cnf.d_network.cnf.j2
@@ -1,6 +1,5 @@
 # Mariadb network settings
-#
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 [mysqld]
 bind_address={{ mariadb_bind_address }}

--- a/templates/etc_my.cnf.d_server.cnf.j2
+++ b/templates/etc_my.cnf.d_server.cnf.j2
@@ -1,6 +1,5 @@
 # MariaDB Server configuration
-#
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 [mariadb]
 {% for key, value in mariadb_server_cnf.items() %}


### PR DESCRIPTION
To support multiline `ansible_managed` comments it is possible to combine them with the `comment` filter.

This PR includes the necessary template changes.