### PR TITLE
Add support for Debian derivatives

### DIFF
--- a/tasks/add-repo.yml
+++ b/tasks/add-repo.yml
@@ -6,7 +6,7 @@
     src: etc_yum.repos.d_mariadb.repo.j2
     dest: /etc/yum.repos.d/MariaDB.repo
     mode: '0644'
-  when: ansible_distribution != 'Debian'
+  when: ansible_os_family != 'Debian'
   tags: mariadb
 
 
@@ -14,14 +14,14 @@
   package:
     name: gpg
     state: latest
-  when: ansible_distribution == 'Debian'
+  when: ansible_os_family == 'Debian'
   tags: mariadb
 
 - name: Add official MariaDB repository key (apt)
   apt_key:
     url: https://mariadb.org/mariadb_release_signing_key.asc
     state: present
-  when: ansible_distribution == 'Debian'
+  when: ansible_os_family == 'Debian'
   tags: mariadb
 
 - name: Add official MariaDB repository (apt)
@@ -29,11 +29,11 @@
     src: etc_apt_sources.list.d_mariadb.list.j2
     dest: /etc/apt/sources.list.d/mariadb.list
     mode: '0644'
-  when: ansible_distribution == 'Debian'
+  when: ansible_os_family == 'Debian'
   tags: mariadb
 
 - name: Update packages cache with new repo (apt)
   apt:
     update_cache: true
-  when: ansible_distribution == 'Debian'
+  when: ansible_os_family == 'Debian'
   tags: mariadb

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -29,5 +29,5 @@
 - name: Install packages
   package:
     name: "{{ mariadb_packages }}"
-    state: "{{ 'latest' if ansible_distribution == 'Debian' else 'installed' }}"
+    state: "{{ 'latest' if ansible_os_family == 'Debian' else 'installed' }}"
   tags: mariadb

--- a/templates/etc_apt_sources.list.d_mariadb.list.j2
+++ b/templates/etc_apt_sources.list.d_mariadb.list.j2
@@ -1,4 +1,4 @@
 # MariaDB repository list - Ansible managed
 # http://downloads.mariadb.org/mariadb/repositories/
-deb [arch=amd64] http://{{ mariadb_mirror }}/{{ mariadb_version }}/debian {{ ansible_distribution_release }} main
-deb-src http://{{ mariadb_mirror }}/{{ mariadb_version }}/debian {{ ansible_distribution_release }} main
+deb [arch=amd64] https://{{ mariadb_mirror }}/{{ mariadb_version }}/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} main
+deb-src https://{{ mariadb_mirror }}/{{ mariadb_version }}/{{ ansible_distribution|lower }} {{ ansible_distribution_release }} main

--- a/templates/etc_logrotate.d_mysql.j2
+++ b/templates/etc_logrotate.d_mysql.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-# This logname can be set in /etc/{{ 'mysql/' if ansible_distribution == 'Debian' else '' }}my.cnf
+# This logname can be set in /etc/{{ 'mysql/' if ansible_os_family == 'Debian' else '' }}my.cnf
 # by setting the variable "log-error"
 # in the [mysqld] section as follows:
 #

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -6,8 +6,6 @@ mariadb_packages:
   - mariadb-server
   - python3-pymysql
 
-mariadb_mirror: mirror.mva-n.net/mariadb/repo
-
 mariadb_socket: /run/mysqld/mysqld.sock
 
 mariadb_config_directory: /etc/mysql/mariadb.conf.d


### PR DESCRIPTION
I have this on the shelves already for a while, but never submitted a PR.. I just ran it a couple of times on Ubuntu (22) and Debian (12/13) and it seems to work fine for both now.

There is still an issue with the Ansible apt-key module, which saves the keys to a deprecated location. Will try to fix that in a separate PR.

This fixes #65 